### PR TITLE
docs(hll): clarify 32-bit hash comments

### DIFF
--- a/pkg/util/hll/hyperloglog.go
+++ b/pkg/util/hll/hyperloglog.go
@@ -70,8 +70,8 @@ func (h *HyperLogLog) Add(data []byte) {
 	h.lock.Lock()
 	defer h.lock.Unlock()
 	
-	// Compute 64-bit hash
-	hash := computeHash(data)
+       // Compute 32-bit hash
+       hash := computeHash(data)
 	
 	// Determine register index using first 'precision' bits
 	idx := hash & (h.m - 1)
@@ -154,7 +154,7 @@ func (h *HyperLogLog) Reset() {
 	}
 }
 
-// computeHash generates a 64-bit hash for the input data.
+// computeHash generates a 32-bit hash for the input data.
 func computeHash(data []byte) uint32 {
 	h := fnv.New32a()
 	h.Write(data)


### PR DESCRIPTION
## Summary
- update HyperLogLog comments to reference 32-bit hash

## Testing
- `go test ./pkg/...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*