### PR TITLE
Update script paths to scripts/dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@
 # Infrastructure
 /.github/            @devops-team
 /deploy/             @devops-team
-/hack/               @devops-team
+/scripts/dev/        @devops-team
 
 # Documentation
 /docs/               @docs-team

--- a/docs/agents/AGENT_RAILS.md
+++ b/docs/agents/AGENT_RAILS.md
@@ -41,7 +41,7 @@ phoenix/
 ├── test/                # Test framework
 ├── docs/                # Documentation
 │   └── adr/             # Architecture Decision Records
-├── hack/                # Development scripts
+├── scripts/dev/         # Development scripts
 ├── deploy/              # Deployment files
 ├── tasks/               # Task definitions
 └── agents/              # Agent role definitions
@@ -53,7 +53,7 @@ To add a new processor, extension, or connector:
 
 1. Call the appropriate script: 
    ```
-   hack/new-component.sh processor example_processor
+   scripts/dev/new-component.sh processor example_processor
    ```
 
 2. This will:

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -16,7 +16,7 @@ Architecture Decision Records are documents that capture important architectural
 Use the script in the repository to create a new ADR:
 
 ```bash
-./hack/new-adr.sh "Title of the ADR"
+./scripts/dev/new-adr.sh "Title of the ADR"
 ```
 
 This will create a new ADR with the correct format and naming convention.

--- a/docs/quickstarts/implementer.md
+++ b/docs/quickstarts/implementer.md
@@ -17,11 +17,11 @@ This guide will help you get started as an Implementer in the Phoenix project.
 
 3. **Create a branch for your task**
    ```bash
-   hack/create-branch.sh implementer PID-001 "Add feature"
+   scripts/dev/create-branch.sh implementer PID-001 "Add feature"
    ```
 
 4. **Write code and tests**
-   - If creating a new component: `hack/new-component.sh processor my_processor`
+   - If creating a new component: `scripts/dev/new-component.sh processor my_processor`
    - Make sure to write tests: `test/interfaces/updateable_processor_test.go` has examples
    - Add appropriate logging and metrics
 
@@ -43,7 +43,7 @@ This guide will help you get started as an Implementer in the Phoenix project.
 ### Adding a new processor
 
 ```bash
-hack/new-component.sh processor my_processor
+scripts/dev/new-component.sh processor my_processor
 ```
 
 ### Implementing the UpdateableProcessor interface

--- a/docs/quickstarts/planner.md
+++ b/docs/quickstarts/planner.md
@@ -15,7 +15,7 @@ This guide will help you get started as a Planner in the Phoenix project.
 
 3. **Create a new task**
    ```bash
-   hack/create-task.sh "Implement feature X"
+   scripts/dev/create-task.sh "Implement feature X"
    ```
 
 4. **Edit the task file to add details**


### PR DESCRIPTION
## Summary
- update references from `hack/` to `scripts/dev/`
- adjust CODEOWNERS to match new directory

## Testing
- `make doc-writer-check` *(fails: markdownlint not found)*