### PR TITLE
Add Go validation utilities

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,9 @@ This directory contains scripts that support development, CI/CD, and validation 
 - **validation/**: Configuration validation scripts
   - **validate_policy_schema.sh**: Validates policy.yaml files against schema
   - **validate_config_schema.sh**: Validates config.yaml files against schema
+  - **validate_policy.go**: CLI tool to validate a policy file
+  - **validate_config.go**: CLI tool to validate a config file against a schema
+  - **generate_config_schemas.go**: Generates JSON schemas for component configs
 
 ## Using the Scripts
 
@@ -25,6 +28,11 @@ Most scripts are self-documenting and will show usage instructions when run with
 ./scripts/dev/new-component.sh processor my_processor
 ./scripts/dev/new-adr.sh "Use PID Controllers for Adaptive Processing"
 ./scripts/validation/validate_policy_schema.sh configs/default/policy.yaml
+# Validate a single policy file
+go run scripts/validation/validate_policy.go configs/default/policy.yaml
+# Generate schemas and validate configs
+go run scripts/validation/generate_config_schemas.go .tmp/schemas
+go run scripts/validation/validate_config.go configs/default/config.yaml .tmp/schemas/default.json
 ```
 
 ## CI Integration

--- a/scripts/validation/generate_config_schemas.go
+++ b/scripts/validation/generate_config_schemas.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/invopop/jsonschema"
+
+	connector "github.com/yourorg/sa-omf/internal/connector/pic_connector"
+	ext "github.com/yourorg/sa-omf/internal/extension/pic_control_ext"
+	pid "github.com/yourorg/sa-omf/internal/processor/adaptive_pid"
+	topk "github.com/yourorg/sa-omf/internal/processor/adaptive_topk"
+	tagger "github.com/yourorg/sa-omf/internal/processor/priority_tagger"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s OUT_DIR\n", filepath.Base(os.Args[0]))
+		os.Exit(1)
+	}
+	outDir := os.Args[1]
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	reflector := jsonschema.Reflector{RequiredFromJSONSchemaTags: true}
+
+	configs := map[string]any{
+		"adaptive_pid":    pid.Config{},
+		"adaptive_topk":   topk.Config{},
+		"priority_tagger": tagger.Config{},
+		"pic_control_ext": ext.Config{},
+		"pic_connector":   connector.Config{},
+	}
+
+	for name, cfg := range configs {
+		schema := reflector.Reflect(cfg)
+		data, err := json.MarshalIndent(schema, "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		file := filepath.Join(outDir, name+".json")
+		if err := os.WriteFile(file, data, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
+}

--- a/scripts/validation/validate_config.go
+++ b/scripts/validation/validate_config.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/xeipuuv/gojsonschema"
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintf(os.Stderr, "usage: %s CONFIG_FILE SCHEMA_FILE\n", filepath.Base(os.Args[0]))
+		os.Exit(1)
+	}
+	configFile := os.Args[1]
+	schemaFile := os.Args[2]
+
+	configData, err := os.ReadFile(configFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	schemaData, err := os.ReadFile(schemaFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reading schema: %v\n", err)
+		os.Exit(1)
+	}
+
+	var jsonData any
+	if err := yaml.Unmarshal(configData, &jsonData); err != nil {
+		fmt.Fprintf(os.Stderr, "parsing YAML: %v\n", err)
+		os.Exit(1)
+	}
+
+	schemaLoader := gojsonschema.NewBytesLoader(schemaData)
+	docLoader := gojsonschema.NewGoLoader(jsonData)
+
+	result, err := gojsonschema.Validate(schemaLoader, docLoader)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "validation error: %v\n", err)
+		os.Exit(1)
+	}
+	if !result.Valid() {
+		for _, err := range result.Errors() {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		os.Exit(1)
+	}
+}

--- a/scripts/validation/validate_config_schema.sh
+++ b/scripts/validation/validate_config_schema.sh
@@ -8,7 +8,7 @@ mkdir -p .tmp/config-schemas
 
 # Generate JSON schemas from Config structs
 echo "Generating JSON schemas from Config structs..."
-go run hack/generate_config_schemas.go .tmp/config-schemas/
+go run scripts/validation/generate_config_schemas.go .tmp/config-schemas/
 
 # Validate config files against schemas
 echo "Validating config files against schemas..."
@@ -18,7 +18,7 @@ for config_file in $(find ./config -name "*.yaml"); do
   
   if [ -f "$schema_file" ]; then
     echo "Checking $config_file against schema..."
-    go run hack/validate_config.go "$config_file" "$schema_file"
+    go run scripts/validation/validate_config.go "$config_file" "$schema_file"
     if [ $? -ne 0 ]; then
       echo "Error: Config file $config_file failed validation"
       exit 1

--- a/scripts/validation/validate_policy.go
+++ b/scripts/validation/validate_policy.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/yourorg/sa-omf/pkg/policy"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s POLICY_FILE\n", os.Args[0])
+		os.Exit(1)
+	}
+	if _, err := policy.LoadPolicy(os.Args[1]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/scripts/validation/validate_policy_schema.sh
+++ b/scripts/validation/validate_policy_schema.sh
@@ -9,7 +9,7 @@ POLICY_FILES=$(find . -name "policy.yaml" -o -name "*policy*.yaml")
 echo "Validating policy files..."
 for policy_file in $POLICY_FILES; do
   echo "Checking $policy_file..."
-  go run hack/validate_policy.go "$policy_file"
+  go run scripts/validation/validate_policy.go "$policy_file"
   if [ $? -ne 0 ]; then
     echo "Error: Policy file $policy_file failed validation"
     exit 1


### PR DESCRIPTION
## Summary
- add Go programs to validate configs and policies
- generate JSON schemas for component configs
- update validation scripts to reference the new programs
- document usage of these new tools

## Testing
- `go test ./...` *(fails: no route to host)*