### PR TITLE
feat: add process context learner processor

### DIFF
--- a/internal/processor/process_context_learner/config.go
+++ b/internal/processor/process_context_learner/config.go
@@ -1,0 +1,21 @@
+package process_context_learner
+
+import "fmt"
+
+// Config defines the configuration for the process_context_learner processor.
+type Config struct {
+	Enabled       bool    `mapstructure:"enabled"`
+	DampingFactor float64 `mapstructure:"damping_factor"`
+	Iterations    int     `mapstructure:"iterations"`
+}
+
+// Validate checks if the configuration is valid.
+func (cfg *Config) Validate() error {
+	if cfg.DampingFactor <= 0 || cfg.DampingFactor >= 1 {
+		return fmt.Errorf("damping_factor must be between 0 and 1")
+	}
+	if cfg.Iterations <= 0 {
+		return fmt.Errorf("iterations must be positive")
+	}
+	return nil
+}

--- a/internal/processor/process_context_learner/factory.go
+++ b/internal/processor/process_context_learner/factory.go
@@ -1,0 +1,35 @@
+package process_context_learner
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor"
+)
+
+// NewFactory creates a factory for the process_context_learner processor.
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		component.MustNewType(typeStr),
+		createDefaultConfig,
+		processor.WithMetrics(createMetricsProcessor, component.StabilityLevelDevelopment),
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{
+		Enabled:       true,
+		DampingFactor: 0.85,
+		Iterations:    10,
+	}
+}
+
+func createMetricsProcessor(
+	ctx context.Context,
+	set processor.CreateSettings,
+	cfg component.Config,
+	next consumer.Metrics,
+) (processor.Metrics, error) {
+	return newProcessor(cfg.(*Config), set, next)
+}

--- a/internal/processor/process_context_learner/processor.go
+++ b/internal/processor/process_context_learner/processor.go
@@ -1,0 +1,212 @@
+package process_context_learner
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+)
+
+const typeStr = "process_context_learner"
+
+// processorImpl implements the process_context_learner processor.
+type processorImpl struct {
+	config *Config
+	logger *zap.Logger
+	next   consumer.Metrics
+
+	lock   sync.RWMutex
+	edges  map[int][]int   // child -> parents (usually length 1)
+	scores map[int]float64 // pid -> importance score
+}
+
+var _ processor.Metrics = (*processorImpl)(nil)
+var _ interfaces.UpdateableProcessor = (*processorImpl)(nil)
+
+func newProcessor(cfg *Config, settings processor.CreateSettings, nextConsumer consumer.Metrics) (*processorImpl, error) {
+	p := &processorImpl{
+		config: cfg,
+		logger: settings.Logger,
+		next:   nextConsumer,
+		edges:  make(map[int][]int),
+		scores: make(map[int]float64),
+	}
+	return p, nil
+}
+
+func (p *processorImpl) Start(ctx context.Context, host component.Host) error {
+	return nil
+}
+
+func (p *processorImpl) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+func (p *processorImpl) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+// ConsumeMetrics processes incoming metrics and updates process importance scores.
+func (p *processorImpl) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if !p.config.Enabled {
+		return p.next.ConsumeMetrics(ctx, md)
+	}
+
+	// Track relationships
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		res := rm.Resource()
+
+		pidAttr, ok1 := res.Attributes().Get("process.pid")
+		ppidAttr, ok2 := res.Attributes().Get("process.parent_pid")
+		if !ok1 || !ok2 {
+			continue
+		}
+		pid := int(pidAttr.Int())
+		ppid := int(ppidAttr.Int())
+		if pid == 0 {
+			continue
+		}
+		// record edge child->parent
+		p.edges[pid] = []int{ppid}
+	}
+
+	p.computeScores()
+
+	// Annotate metrics with scores
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		res := rm.Resource()
+		pidAttr, ok := res.Attributes().Get("process.pid")
+		if !ok {
+			continue
+		}
+		pid := int(pidAttr.Int())
+		if score, ok := p.scores[pid]; ok {
+			res.Attributes().PutDouble("aemf.process.importance", score)
+		}
+	}
+
+	return p.next.ConsumeMetrics(ctx, md)
+}
+
+func (p *processorImpl) computeScores() {
+	nodes := make(map[int]struct{})
+	for pid, parents := range p.edges {
+		nodes[pid] = struct{}{}
+		for _, parent := range parents {
+			if parent != 0 {
+				nodes[parent] = struct{}{}
+			}
+		}
+	}
+	n := len(nodes)
+	if n == 0 {
+		return
+	}
+
+	// Initialize scores
+	scores := make(map[int]float64, n)
+	for id := range nodes {
+		scores[id] = 1.0 / float64(n)
+	}
+
+	damping := p.config.DampingFactor
+	iterations := p.config.Iterations
+
+	for i := 0; i < iterations; i++ {
+		newScores := make(map[int]float64, n)
+		for id := range nodes {
+			newScores[id] = (1 - damping) / float64(n)
+		}
+
+		sinkSum := 0.0
+		for id := range nodes {
+			if len(p.edges[id]) == 0 {
+				sinkSum += scores[id]
+			}
+		}
+		sinkContribution := damping * sinkSum / float64(n)
+		for id := range nodes {
+			newScores[id] += sinkContribution
+		}
+
+		for child, parents := range p.edges {
+			if len(parents) == 0 {
+				continue
+			}
+			share := damping * scores[child] / float64(len(parents))
+			for _, parent := range parents {
+				newScores[parent] += share
+			}
+		}
+		scores = newScores
+	}
+
+	p.scores = scores
+}
+
+// GetConfigStatus implements the UpdateableProcessor interface.
+func (p *processorImpl) GetConfigStatus(ctx context.Context) (interfaces.ConfigStatus, error) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return interfaces.ConfigStatus{
+		Parameters: map[string]any{
+			"damping_factor": p.config.DampingFactor,
+			"iterations":     p.config.Iterations,
+		},
+		Enabled: p.config.Enabled,
+	}, nil
+}
+
+// OnConfigPatch implements the UpdateableProcessor interface.
+func (p *processorImpl) OnConfigPatch(ctx context.Context, patch interfaces.ConfigPatch) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	switch patch.ParameterPath {
+	case "enabled":
+		enabled, ok := patch.NewValue.(bool)
+		if !ok {
+			return nil
+		}
+		p.config.Enabled = enabled
+	case "damping_factor":
+		v, ok := patch.NewValue.(float64)
+		if !ok {
+			return nil
+		}
+		p.config.DampingFactor = v
+	case "iterations":
+		v, ok := patch.NewValue.(int)
+		if !ok {
+			return nil
+		}
+		p.config.Iterations = v
+	default:
+		return nil
+	}
+
+	return p.config.Validate()
+}
+
+// GetScores returns the current importance scores.
+func (p *processorImpl) GetScores() map[int]float64 {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+	out := make(map[int]float64, len(p.scores))
+	for k, v := range p.scores {
+		out[k] = v
+	}
+	return out
+}

--- a/test/processors/process_context_learner/processor_test.go
+++ b/test/processors/process_context_learner/processor_test.go
@@ -1,0 +1,90 @@
+package process_context_learner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	learner "github.com/deepaucksharma/Phoenix/internal/processor/process_context_learner"
+)
+
+func TestProcessContextLearner(t *testing.T) {
+	factory := learner.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*learner.Config)
+	cfg.Enabled = true
+
+	sink := new(consumertest.MetricsSink)
+	ctx := context.Background()
+	settings := processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+		ID:                component.NewIDWithName(component.MustNewType("process_context_learner"), ""),
+	}
+
+	proc, err := factory.CreateMetrics(ctx, settings, cfg, sink)
+	require.NoError(t, err)
+
+	err = proc.Start(ctx, nil)
+	require.NoError(t, err)
+
+	metrics := generateTestMetrics()
+	err = proc.ConsumeMetrics(ctx, metrics)
+	require.NoError(t, err)
+
+	processed := sink.AllMetrics()
+	require.Len(t, processed, 1)
+
+	rm := processed[0].ResourceMetrics()
+	for i := 0; i < rm.Len(); i++ {
+		res := rm.At(i).Resource()
+		_, ok := res.Attributes().Get("aemf.process.importance")
+		assert.True(t, ok, "importance attribute missing")
+	}
+
+	lp := proc.(*learner.processorImpl)
+	scores := lp.GetScores()
+	require.Len(t, scores, 4)
+
+	assert.Greater(t, scores[1], scores[2])
+	assert.Greater(t, scores[2], scores[3])
+	assert.Greater(t, scores[2], scores[4])
+
+	err = proc.Shutdown(ctx)
+	require.NoError(t, err)
+}
+
+func generateTestMetrics() pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	relationships := []struct{ pid, ppid int }{
+		{1, 0},
+		{2, 1},
+		{3, 2},
+		{4, 1},
+	}
+
+	for _, r := range relationships {
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutInt("process.pid", int64(r.pid))
+		rm.Resource().Attributes().PutInt("process.parent_pid", int64(r.ppid))
+
+		sm := rm.ScopeMetrics().AppendEmpty()
+		sm.Scope().SetName("test.scope")
+
+		metric := sm.Metrics().AppendEmpty()
+		metric.SetName("test.metric")
+		metric.SetEmptyGauge()
+		dp := metric.Gauge().DataPoints().AppendEmpty()
+		dp.SetIntValue(100)
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	}
+
+	return metrics
+}


### PR DESCRIPTION
## Summary
- implement new `process_context_learner` processor for learning parent/child
  relationships and computing importance scores
- expose default config and factory
- attach computed scores to resource metrics
- add unit tests for relationship tracking and ranking

## Testing
- `make lint` *(fails: golangci-lint not found)*
- `make test` *(fails: cannot download modules)*