### PR TITLE
Add others rollup processor

### DIFF
--- a/internal/processor/others_rollup/README.md
+++ b/internal/processor/others_rollup/README.md
@@ -1,0 +1,36 @@
+# others_rollup Processor
+
+The `others_rollup` processor aggregates metrics from low priority processes into
+a single synthetic resource named `others`. This reduces metric cardinality when
+many low impact processes are present.
+
+## Configuration
+
+```yaml
+processors:
+  others_rollup:
+    enabled: true
+    strategy: sum # or "avg"
+```
+
+- `enabled`  – toggles whether aggregation is applied.
+- `strategy` – aggregation strategy used for numeric values. Supported values are
+  `sum` and `avg`.
+
+## Dynamic Configuration
+
+The processor implements the `UpdateableProcessor` interface. The following
+configuration parameters can be patched at runtime:
+
+- `enabled`
+- `strategy`
+
+Example patch:
+```json
+{
+  "patch_id": "switch-to-avg",
+  "target_processor_name": "others_rollup",
+  "parameter_path": "strategy",
+  "new_value": "avg"
+}
+```

--- a/internal/processor/others_rollup/config.go
+++ b/internal/processor/others_rollup/config.go
@@ -1,0 +1,25 @@
+package others_rollup
+
+import "fmt"
+
+// Package others_rollup aggregates metrics from low priority processes into a single
+// synthetic resource.
+
+// Config defines configuration for the others_rollup processor.
+type Config struct {
+	Strategy string `mapstructure:"strategy"` // Aggregation strategy: sum or avg
+	Enabled  bool   `mapstructure:"enabled"`
+}
+
+// Validate checks if the configuration is valid.
+func (cfg *Config) Validate() error {
+	if cfg.Strategy == "" {
+		cfg.Strategy = "sum"
+	}
+	switch cfg.Strategy {
+	case "sum", "avg":
+		return nil
+	default:
+		return fmt.Errorf("invalid strategy %s", cfg.Strategy)
+	}
+}

--- a/internal/processor/others_rollup/factory.go
+++ b/internal/processor/others_rollup/factory.go
@@ -1,0 +1,39 @@
+package others_rollup
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor"
+)
+
+const typeStr = "others_rollup"
+
+// NewFactory creates a factory for the others_rollup processor.
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		component.MustNewType(typeStr),
+		createDefaultConfig,
+		processor.WithMetrics(createMetricsProcessor, component.StabilityLevelDevelopment),
+	)
+}
+
+// createDefaultConfig creates default configuration for the processor.
+func createDefaultConfig() component.Config {
+	return &Config{
+		Strategy: "sum",
+		Enabled:  false,
+	}
+}
+
+// createMetricsProcessor creates the processor instance.
+func createMetricsProcessor(
+	ctx context.Context,
+	set processor.CreateSettings,
+	cfg component.Config,
+	next consumer.Metrics,
+) (processor.Metrics, error) {
+	pCfg := cfg.(*Config)
+	return newProcessor(pCfg, set, next)
+}

--- a/internal/processor/others_rollup/processor.go
+++ b/internal/processor/others_rollup/processor.go
@@ -1,0 +1,204 @@
+package others_rollup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+)
+
+const (
+	typeStr          = "others_rollup"
+	lowPriorityValue = "low"
+	priorityAttr     = "aemf.process.priority"
+)
+
+// processorImpl aggregates metrics for low priority processes.
+type processorImpl struct {
+	config *Config
+	logger *zap.Logger
+	next   consumer.Metrics
+	lock   sync.RWMutex
+}
+
+var _ processor.Metrics = (*processorImpl)(nil)
+var _ interfaces.UpdateableProcessor = (*processorImpl)(nil)
+
+// newProcessor creates a new others_rollup processor.
+func newProcessor(cfg *Config, settings processor.CreateSettings, next consumer.Metrics) (*processorImpl, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &processorImpl{
+		config: cfg,
+		logger: settings.Logger,
+		next:   next,
+	}, nil
+}
+
+// Start implements the component.Component interface.
+func (p *processorImpl) Start(ctx context.Context, host component.Host) error {
+	return nil
+}
+
+// Shutdown implements the component.Component interface.
+func (p *processorImpl) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+// Capabilities implements the processor.Metrics interface.
+func (p *processorImpl) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+// ConsumeMetrics aggregates low priority process metrics.
+func (p *processorImpl) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if !p.config.Enabled {
+		return p.next.ConsumeMetrics(ctx, md)
+	}
+
+	out := pmetric.NewMetrics()
+	out.ResourceMetrics().EnsureCapacity(md.ResourceMetrics().Len())
+
+	// Aggregation map
+	type agg struct {
+		sum   float64
+		count int
+		typ   pmetric.MetricType
+	}
+	metricsAgg := map[string]*agg{}
+
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		attrs := rm.Resource().Attributes()
+		if val, ok := attrs.Get(priorityAttr); ok && val.Str() == lowPriorityValue {
+			// Aggregate metrics
+			for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+				sm := rm.ScopeMetrics().At(j)
+				for k := 0; k < sm.Metrics().Len(); k++ {
+					m := sm.Metrics().At(k)
+					var value float64
+					switch m.Type() {
+					case pmetric.MetricTypeGauge:
+						if m.Gauge().DataPoints().Len() == 0 {
+							continue
+						}
+						value = m.Gauge().DataPoints().At(0).DoubleValue()
+					case pmetric.MetricTypeSum:
+						if m.Sum().DataPoints().Len() == 0 {
+							continue
+						}
+						value = m.Sum().DataPoints().At(0).DoubleValue()
+					default:
+						continue
+					}
+					a := metricsAgg[m.Name()]
+					if a == nil {
+						a = &agg{typ: m.Type()}
+						metricsAgg[m.Name()] = a
+					}
+					a.sum += value
+					a.count++
+				}
+			}
+		} else {
+			// Keep as is
+			newRM := out.ResourceMetrics().AppendEmpty()
+			rm.CopyTo(newRM)
+		}
+	}
+
+	// Build aggregated resource if any metrics aggregated
+	if len(metricsAgg) > 0 {
+		aggRM := out.ResourceMetrics().AppendEmpty()
+		res := aggRM.Resource()
+		res.Attributes().PutStr("process.name", "others")
+		res.Attributes().PutStr(priorityAttr, lowPriorityValue)
+
+		sm := aggRM.ScopeMetrics().AppendEmpty()
+		sm.Scope().SetName(typeStr)
+
+		now := pcommon.NewTimestampFromTime(time.Now())
+		for name, a := range metricsAgg {
+			m := sm.Metrics().AppendEmpty()
+			m.SetName(name)
+			switch a.typ {
+			case pmetric.MetricTypeSum:
+				sum := m.SetEmptySum()
+				sum.SetIsMonotonic(true)
+				sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				dp := sum.DataPoints().AppendEmpty()
+				val := a.sum
+				if p.config.Strategy == "avg" && a.count > 0 {
+					val = a.sum / float64(a.count)
+				}
+				dp.SetDoubleValue(val)
+				dp.SetTimestamp(now)
+			default:
+				gauge := m.SetEmptyGauge()
+				dp := gauge.DataPoints().AppendEmpty()
+				val := a.sum
+				if p.config.Strategy == "avg" && a.count > 0 {
+					val = a.sum / float64(a.count)
+				}
+				dp.SetDoubleValue(val)
+				dp.SetTimestamp(now)
+			}
+		}
+	}
+
+	return p.next.ConsumeMetrics(ctx, out)
+}
+
+// OnConfigPatch implements UpdateableProcessor.
+func (p *processorImpl) OnConfigPatch(ctx context.Context, patch interfaces.ConfigPatch) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	switch patch.ParameterPath {
+	case "enabled":
+		if v, ok := patch.NewValue.(bool); ok {
+			p.config.Enabled = v
+		} else {
+			return fmt.Errorf("invalid type for enabled")
+		}
+	case "strategy":
+		if s, ok := patch.NewValue.(string); ok {
+			p.config.Strategy = s
+			if err := p.config.Validate(); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("invalid type for strategy")
+		}
+	default:
+		return fmt.Errorf("unknown parameter %s", patch.ParameterPath)
+	}
+
+	return nil
+}
+
+// GetConfigStatus implements UpdateableProcessor.
+func (p *processorImpl) GetConfigStatus(ctx context.Context) (interfaces.ConfigStatus, error) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	return interfaces.ConfigStatus{
+		Parameters: map[string]any{
+			"strategy": p.config.Strategy,
+		},
+		Enabled: p.config.Enabled,
+	}, nil
+}

--- a/test/integration/others_rollup_test.go
+++ b/test/integration/others_rollup_test.go
@@ -1,0 +1,72 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/others_rollup"
+	"github.com/deepaucksharma/Phoenix/internal/processor/priority_tagger"
+	"github.com/deepaucksharma/Phoenix/test/testutils"
+)
+
+// TestOthersRollupIntegration verifies that low priority processes are rolled up
+// into a single synthetic resource when used with priority_tagger.
+func TestOthersRollupIntegration(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup priority_tagger
+	ptFactory := priority_tagger.NewFactory()
+	ptCfg := ptFactory.CreateDefaultConfig().(*priority_tagger.Config)
+	ptCfg.Rules = []priority_tagger.Rule{
+		{Match: "nginx.*", Priority: "high"},
+		{Match: ".*mysql.*", Priority: "critical"},
+		{Match: "background.*", Priority: "low"},
+		{Match: "other.*", Priority: "low"},
+	}
+	ptCfg.Enabled = true
+
+	// Setup others_rollup
+	orFactory := others_rollup.NewFactory()
+	orCfg := orFactory.CreateDefaultConfig().(*others_rollup.Config)
+	orCfg.Enabled = true
+	orCfg.Strategy = "sum"
+
+	sink := new(consumertest.MetricsSink)
+
+	// Build pipeline: priority_tagger -> others_rollup -> sink
+	orProc, err := orFactory.CreateMetricsProcessor(ctx, processor.CreateSettings{}, orCfg, sink)
+	require.NoError(t, err)
+	ptProc, err := ptFactory.CreateMetricsProcessor(ctx, processor.CreateSettings{}, ptCfg, orProc)
+	require.NoError(t, err)
+
+	require.NoError(t, orProc.Start(ctx, nil))
+	require.NoError(t, ptProc.Start(ctx, nil))
+
+	metrics := testutils.GenerateMetrics()
+	require.NoError(t, ptProc.ConsumeMetrics(ctx, metrics))
+
+	out := sink.AllMetrics()
+	require.Len(t, out, 1)
+
+	rms := out[0].ResourceMetrics()
+	require.Equal(t, 3, rms.Len())
+
+	var othersFound bool
+	for i := 0; i < rms.Len(); i++ {
+		rm := rms.At(i)
+		attrs := rm.Resource().Attributes()
+		if v, ok := attrs.Get("process.name"); ok && v.Str() == "others" {
+			othersFound = true
+			prio, _ := attrs.Get("aemf.process.priority")
+			require.Equal(t, "low", prio.Str())
+		}
+	}
+	require.True(t, othersFound, "aggregated 'others' resource not found")
+
+	require.NoError(t, ptProc.Shutdown(ctx))
+	require.NoError(t, orProc.Shutdown(ctx))
+}


### PR DESCRIPTION
## Summary
- implement `others_rollup` processor for aggregating low priority processes
- provide config and factory for strategy/enablement
- expose UpdateableProcessor methods
- document configuration and usage
- add integration test with priority_tagger

## Testing
- `go test ./...` *(fails: no route to host)*