### PR TITLE
Add OpAMP client with mTLS

### DIFF
--- a/internal/extension/pic_control_ext/extension.go
+++ b/internal/extension/pic_control_ext/extension.go
@@ -2,12 +2,18 @@
 package pic_control_ext
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
-        "strings"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,11 +32,11 @@ const (
 )
 
 var (
-	errPolicyLoadFailed = errors.New("failed to load policy")
+	errPolicyLoadFailed  = errors.New("failed to load policy")
 	errProcessorNotFound = errors.New("target processor not found")
-	errPatchRateLimited = errors.New("patch rate limited")
-	errSafeModeActive = errors.New("safe mode active")
-	errPatchExpired = errors.New("patch has expired")
+	errPatchRateLimited  = errors.New("patch rate limited")
+	errSafeModeActive    = errors.New("safe mode active")
+	errPatchExpired      = errors.New("patch has expired")
 )
 
 // Config defines configuration for the pic_control extension
@@ -44,8 +50,12 @@ type Config struct {
 
 // OpAMPClientConfig defines configuration for the OpAMP client
 type OpAMPClientConfig struct {
-	ServerURL          string `mapstructure:"server_url"`
-	InsecureSkipVerify bool   `mapstructure:"insecure_skip_verify"`
+	ServerURL           string `mapstructure:"server_url"`
+	InsecureSkipVerify  bool   `mapstructure:"insecure_skip_verify"`
+	ClientCertFile      string `mapstructure:"client_cert_file"`
+	ClientKeyFile       string `mapstructure:"client_key_file"`
+	CACertFile          string `mapstructure:"ca_cert_file"`
+	PollIntervalSeconds int    `mapstructure:"poll_interval_seconds"`
 }
 
 // NewFactory creates a factory for the pic_control extension
@@ -61,10 +71,13 @@ func NewFactory() extension.Factory {
 // createDefaultConfig creates the default configuration
 func createDefaultConfig() component.Config {
 	return &Config{
-		PolicyFilePath:      "/etc/sa-omf/policy.yaml",
-		MaxPatchesPerMinute: 3,
+		PolicyFilePath:       "/etc/sa-omf/policy.yaml",
+		MaxPatchesPerMinute:  3,
 		PatchCooldownSeconds: 10,
-		SafeModeConfigs:     make(map[string]interface{}),
+		SafeModeConfigs:      make(map[string]interface{}),
+		OpAMPConfig: &OpAMPClientConfig{
+			PollIntervalSeconds: 5,
+		},
 	}
 }
 
@@ -75,7 +88,7 @@ func createExtension(
 	cfg component.Config,
 ) (extension.Extension, error) {
 	config := cfg.(*Config)
-	
+
 	// Create extension
 	return newExtension(config, set.Logger)
 }
@@ -123,40 +136,40 @@ func newExtension(config *Config, logger *zap.Logger) (*Extension, error) {
 // Start starts the extension
 func (e *Extension) Start(ctx context.Context, host component.Host) error {
 	e.host = host
-	
+
 	// Set up metrics
 	// This needs a concrete implementation of metric.MeterProvider
 	// We'll leave this commented for now
 	/*
-	metricProvider := host.GetExtensions()[component.MustNewID("prometheus")]
-	if metricProvider != nil {
-		e.metrics = metrics.NewMetricsEmitter(metricProvider.(metric.MeterProvider).Meter("pic_control"), 
-		                                     "pic_control", component.MustNewID(typeStr))
-	}
+		metricProvider := host.GetExtensions()[component.MustNewID("prometheus")]
+		if metricProvider != nil {
+			e.metrics = metrics.NewMetricsEmitter(metricProvider.(metric.MeterProvider).Meter("pic_control"),
+			                                     "pic_control", component.MustNewID(typeStr))
+		}
 	*/
-	
+
 	// Register processors
 	if err := e.registerProcessors(); err != nil {
 		return fmt.Errorf("registering processors: %w", err)
 	}
-	
+
 	// Load initial policy
 	if err := e.loadPolicy(e.config.PolicyFilePath); err != nil {
 		return fmt.Errorf("loading initial policy: %w", err)
 	}
-	
+
 	// Start policy file watcher
 	if err := e.startWatcher(); err != nil {
 		return fmt.Errorf("starting policy watcher: %w", err)
 	}
-	
+
 	// Start OpAMP client if configured
 	if e.config.OpAMPConfig != nil {
 		if err := e.startOpAMPClient(ctx); err != nil {
 			e.logger.Warn("Failed to start OpAMP client", zap.Error(err))
 		}
 	}
-	
+
 	return nil
 }
 
@@ -166,11 +179,11 @@ func (e *Extension) Shutdown(ctx context.Context) error {
 	if e.cancelWatcher != nil {
 		e.cancelWatcher()
 	}
-	
+
 	if e.watcher != nil {
 		return e.watcher.Close()
 	}
-	
+
 	return nil
 }
 
@@ -179,7 +192,7 @@ func (e *Extension) registerProcessors() error {
 	if e.host == nil {
 		return fmt.Errorf("host not initialized")
 	}
-	
+
 	// Check all processors from the host
 	for id, proc := range e.host.GetProcessors() {
 		// Try to cast to UpdateableProcessor
@@ -188,7 +201,7 @@ func (e *Extension) registerProcessors() error {
 			e.logger.Info("Registered updateable processor", zap.String("id", id.String()))
 		}
 	}
-	
+
 	return nil
 }
 
@@ -196,59 +209,59 @@ func (e *Extension) registerProcessors() error {
 func (e *Extension) SubmitConfigPatch(ctx context.Context, patch interfaces.ConfigPatch) error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
-	
+
 	// Check if safe mode is active
 	if e.safeMode {
-		e.logger.Warn("Patch rejected: Safe mode active", 
-		              zap.String("patch_id", patch.PatchID),
-		              zap.String("target", patch.TargetProcessorName.String()))
+		e.logger.Warn("Patch rejected: Safe mode active",
+			zap.String("patch_id", patch.PatchID),
+			zap.String("target", patch.TargetProcessorName.String()))
 		return errSafeModeActive
 	}
-	
+
 	// Check patch TTL
 	if patch.Timestamp > 0 && patch.TTLSeconds > 0 {
 		expirationTime := time.Unix(patch.Timestamp, 0).Add(time.Duration(patch.TTLSeconds) * time.Second)
 		if time.Now().After(expirationTime) {
-			e.logger.Warn("Patch rejected: Expired", 
-			              zap.String("patch_id", patch.PatchID),
-			              zap.Time("expiration", expirationTime))
+			e.logger.Warn("Patch rejected: Expired",
+				zap.String("patch_id", patch.PatchID),
+				zap.Time("expiration", expirationTime))
 			return errPatchExpired
 		}
 	}
-	
+
 	// Check rate limiting
 	if !e.checkRateLimit() {
-		e.logger.Warn("Patch rejected: Rate limited", 
-		              zap.String("patch_id", patch.PatchID),
-		              zap.String("target", patch.TargetProcessorName.String()))
+		e.logger.Warn("Patch rejected: Rate limited",
+			zap.String("patch_id", patch.PatchID),
+			zap.String("target", patch.TargetProcessorName.String()))
 		return errPatchRateLimited
 	}
-	
+
 	// Check cooldown
-	if !e.lastPatchTime.IsZero() && 
-	   time.Since(e.lastPatchTime) < time.Duration(e.config.PatchCooldownSeconds)*time.Second {
-		e.logger.Warn("Patch rejected: Cooldown active", 
-		              zap.String("patch_id", patch.PatchID),
-		              zap.Duration("remaining", 
-		              time.Duration(e.config.PatchCooldownSeconds)*time.Second - time.Since(e.lastPatchTime)))
+	if !e.lastPatchTime.IsZero() &&
+		time.Since(e.lastPatchTime) < time.Duration(e.config.PatchCooldownSeconds)*time.Second {
+		e.logger.Warn("Patch rejected: Cooldown active",
+			zap.String("patch_id", patch.PatchID),
+			zap.Duration("remaining",
+				time.Duration(e.config.PatchCooldownSeconds)*time.Second-time.Since(e.lastPatchTime)))
 		return errPatchRateLimited
 	}
-	
+
 	// Get the target processor
 	processor, exists := e.processors[patch.TargetProcessorName]
 	if !exists {
-		e.logger.Warn("Patch rejected: Target processor not found", 
-		              zap.String("patch_id", patch.PatchID),
-		              zap.String("target", patch.TargetProcessorName.String()))
+		e.logger.Warn("Patch rejected: Target processor not found",
+			zap.String("patch_id", patch.PatchID),
+			zap.String("target", patch.TargetProcessorName.String()))
 		return errProcessorNotFound
 	}
-	
+
 	// Get current status to set PrevValue
 	status, err := processor.GetConfigStatus(ctx)
 	if err != nil {
-		e.logger.Warn("Failed to get processor status", 
-		              zap.String("processor", patch.TargetProcessorName.String()),
-		              zap.Error(err))
+		e.logger.Warn("Failed to get processor status",
+			zap.String("processor", patch.TargetProcessorName.String()),
+			zap.Error(err))
 	} else if status.Parameters != nil {
 		// Try to find the parameter in the current status
 		// This is simplified; in a real implementation, we would traverse the parameter path
@@ -256,34 +269,34 @@ func (e *Extension) SubmitConfigPatch(ctx context.Context, patch interfaces.Conf
 			patch.PrevValue = val
 		}
 	}
-	
+
 	// Apply the patch
 	err = processor.OnConfigPatch(ctx, patch)
 	if err != nil {
-		e.logger.Warn("Failed to apply patch", 
-		              zap.String("patch_id", patch.PatchID),
-		              zap.String("target", patch.TargetProcessorName.String()),
-		              zap.Error(err))
+		e.logger.Warn("Failed to apply patch",
+			zap.String("patch_id", patch.PatchID),
+			zap.String("target", patch.TargetProcessorName.String()),
+			zap.Error(err))
 		return err
 	}
-	
+
 	// Update rate limiting state
 	e.lastPatchTime = time.Now()
 	e.patchCount++
-	
+
 	// Record patch in history
 	e.patchHistory = append(e.patchHistory, patch)
 	if len(e.patchHistory) > 100 {
 		// Keep last 100 patches
 		e.patchHistory = e.patchHistory[len(e.patchHistory)-100:]
 	}
-	
-	e.logger.Info("Applied patch", 
-	              zap.String("patch_id", patch.PatchID),
-	              zap.String("target", patch.TargetProcessorName.String()),
-	              zap.String("parameter", patch.ParameterPath),
-	              zap.Any("new_value", patch.NewValue))
-	
+
+	e.logger.Info("Applied patch",
+		zap.String("patch_id", patch.PatchID),
+		zap.String("target", patch.TargetProcessorName.String()),
+		zap.String("parameter", patch.ParameterPath),
+		zap.Any("new_value", patch.NewValue))
+
 	return nil
 }
 
@@ -294,7 +307,7 @@ func (e *Extension) checkRateLimit() bool {
 		e.patchCount = 0
 		e.patchCountReset = time.Now()
 	}
-	
+
 	return e.patchCount < e.config.MaxPatchesPerMinute
 }
 
@@ -304,17 +317,28 @@ func (e *Extension) loadPolicy(filename string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	e.policy = newPolicy
-	
+
 	// Apply initial processor configurations from policy
+	return e.applyPolicyConfig()
+}
+
+// loadPolicyBytes loads policy YAML from memory and applies it.
+func (e *Extension) loadPolicyBytes(data []byte) error {
+	newPolicy, err := policy.ParsePolicy(data)
+	if err != nil {
+		return err
+	}
+
+	e.policy = newPolicy
 	return e.applyPolicyConfig()
 }
 
 // applyPolicyConfig applies the processor configurations from the policy
 func (e *Extension) applyPolicyConfig() error {
 	ctx := context.Background()
-	
+
 	// Apply configurations to each processor
 	for id, processor := range e.processors {
 		// Extract the processor type from the ID
@@ -323,7 +347,7 @@ func (e *Extension) applyPolicyConfig() error {
 			continue
 		}
 		procType := parts[len(parts)-1]
-		
+
 		// Check if this processor type has a configuration in the policy
 		if procConfig, exists := e.policy.ProcessorsConfig[procType]; exists {
 			// Create a ConfigPatch for each parameter
@@ -332,7 +356,7 @@ func (e *Extension) applyPolicyConfig() error {
 				if paramName == "enabled" {
 					continue
 				}
-				
+
 				patch := interfaces.ConfigPatch{
 					PatchID:             fmt.Sprintf("policy-init-%s-%s", procType, paramName),
 					TargetProcessorName: id,
@@ -344,24 +368,24 @@ func (e *Extension) applyPolicyConfig() error {
 					Timestamp:           time.Now().Unix(),
 					TTLSeconds:          0, // No expiration for initial config
 				}
-				
+
 				// Apply the patch
 				err := processor.OnConfigPatch(ctx, patch)
 				if err != nil {
 					e.logger.Warn("Failed to apply initial policy configuration",
-					              zap.String("processor", id.String()),
-					              zap.String("parameter", paramName),
-					              zap.Error(err))
+						zap.String("processor", id.String()),
+						zap.String("parameter", paramName),
+						zap.Error(err))
 				} else {
 					e.logger.Info("Applied initial policy configuration",
-					             zap.String("processor", id.String()),
-					             zap.String("parameter", paramName),
-					             zap.Any("value", paramValue))
+						zap.String("processor", id.String()),
+						zap.String("parameter", paramName),
+						zap.Any("value", paramValue))
 				}
 			}
 		}
 	}
-	
+
 	return nil
 }
 
@@ -372,75 +396,176 @@ func (e *Extension) startWatcher() error {
 	if err != nil {
 		return err
 	}
-	
+
 	// Watch the directory, not the file
 	dir := filepath.Dir(e.config.PolicyFilePath)
 	err = e.watcher.Add(dir)
 	if err != nil {
 		return err
 	}
-	
+
 	// Start watcher goroutine
 	ctx, cancel := context.WithCancel(context.Background())
 	e.cancelWatcher = cancel
-	
+
 	go func() {
 		defer e.watcher.Close()
-		
+
 		for {
 			select {
 			case event, ok := <-e.watcher.Events:
 				if !ok {
 					return
 				}
-				
+
 				// Check if this is for our policy file
 				if event.Name == e.config.PolicyFilePath {
 					if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
 						e.logger.Info("Policy file changed, reloading")
-						
+
 						// Wait a brief moment for the file to be completely written
 						time.Sleep(100 * time.Millisecond)
-						
+
 						if err := e.loadPolicy(e.config.PolicyFilePath); err != nil {
 							e.logger.Error("Failed to reload policy file", zap.Error(err))
 						}
 					}
 				}
-				
+
 			case err, ok := <-e.watcher.Errors:
 				if !ok {
 					return
 				}
 				e.logger.Error("Policy watcher error", zap.Error(err))
-				
+
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
-	
+
 	return nil
 }
 
 // startOpAMPClient starts the OpAMP client
 func (e *Extension) startOpAMPClient(ctx context.Context) error {
-	// Placeholder for OpAMP client implementation
+	cfg := e.config.OpAMPConfig
+	if cfg == nil {
+		return nil
+	}
+
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: cfg.InsecureSkipVerify}
+
+	if cfg.CACertFile != "" {
+		caData, err := os.ReadFile(cfg.CACertFile)
+		if err != nil {
+			return fmt.Errorf("read CA cert: %w", err)
+		}
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(caData)
+		tlsCfg.RootCAs = pool
+	}
+
+	if cfg.ClientCertFile != "" && cfg.ClientKeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(cfg.ClientCertFile, cfg.ClientKeyFile)
+		if err != nil {
+			return fmt.Errorf("load client cert: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsCfg}}
+
+	go func() {
+		ticker := time.NewTicker(time.Duration(cfg.PollIntervalSeconds) * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				e.pollOpAMPServer(ctx, client)
+			}
+		}
+	}()
+
 	return nil
+}
+
+func (e *Extension) pollOpAMPServer(ctx context.Context, client *http.Client) {
+	e.sendStatus(ctx, client)
+
+	// Fetch policy
+	resp, err := client.Get(e.config.OpAMPConfig.ServerURL + "/policy")
+	if err == nil {
+		if resp.StatusCode == http.StatusOK {
+			data, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err == nil {
+				if err := e.loadPolicyBytes(data); err != nil {
+					e.logger.Warn("Failed to apply remote policy", zap.Error(err))
+				} else {
+					e.logger.Info("Applied remote policy")
+				}
+			}
+		} else {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	} else {
+		e.logger.Warn("Failed to fetch policy", zap.Error(err))
+	}
+
+	// Fetch patch
+	resp, err = client.Get(e.config.OpAMPConfig.ServerURL + "/patch")
+	if err == nil {
+		if resp.StatusCode == http.StatusOK {
+			var patch interfaces.ConfigPatch
+			if err := json.NewDecoder(resp.Body).Decode(&patch); err == nil {
+				resp.Body.Close()
+				if err := e.SubmitConfigPatch(ctx, patch); err != nil {
+					e.logger.Warn("Failed to apply remote patch", zap.Error(err))
+				} else {
+					e.logger.Info("Applied remote patch", zap.String("patch_id", patch.PatchID))
+				}
+			} else {
+				resp.Body.Close()
+				e.logger.Warn("Failed to decode patch", zap.Error(err))
+			}
+		} else {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	} else {
+		e.logger.Warn("Failed to fetch patch", zap.Error(err))
+	}
+}
+
+func (e *Extension) sendStatus(ctx context.Context, client *http.Client) {
+	status := map[string]any{"safe_mode": e.safeMode}
+	body, _ := json.Marshal(status)
+	resp, err := client.Post(e.config.OpAMPConfig.ServerURL+"/status", "application/json", bytes.NewReader(body))
+	if err != nil {
+		e.logger.Warn("Failed to send status", zap.Error(err))
+		return
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
 }
 
 // enterSafeMode puts the system into safe mode
 func (e *Extension) enterSafeMode() error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
-	
+
 	if e.safeMode {
 		return nil // Already in safe mode
 	}
-	
+
 	e.safeMode = true
 	e.logger.Warn("Entering safe mode")
-	
+
 	// Apply safe mode configurations to all processors
 	ctx := context.Background()
 	for id, processor := range e.processors {
@@ -450,7 +575,7 @@ func (e *Extension) enterSafeMode() error {
 			continue
 		}
 		procType := parts[len(parts)-1]
-		
+
 		// Check if this processor has a safe mode config
 		if safeConfig, exists := e.config.SafeModeConfigs[procType]; exists {
 			if configMap, ok := safeConfig.(map[string]interface{}); ok {
@@ -466,25 +591,25 @@ func (e *Extension) enterSafeMode() error {
 						Timestamp:           time.Now().Unix(),
 						TTLSeconds:          0, // No expiration for safe mode
 					}
-					
+
 					// Apply the patch
 					err := processor.OnConfigPatch(ctx, patch)
 					if err != nil {
 						e.logger.Warn("Failed to apply safe mode configuration",
-						              zap.String("processor", id.String()),
-						              zap.String("parameter", paramName),
-						              zap.Error(err))
+							zap.String("processor", id.String()),
+							zap.String("parameter", paramName),
+							zap.Error(err))
 					} else {
 						e.logger.Info("Applied safe mode configuration",
-						             zap.String("processor", id.String()),
-						             zap.String("parameter", paramName),
-						             zap.Any("value", paramValue))
+							zap.String("processor", id.String()),
+							zap.String("parameter", paramName),
+							zap.Any("value", paramValue))
 					}
 				}
 			}
 		}
 	}
-	
+
 	return nil
 }
 
@@ -492,14 +617,14 @@ func (e *Extension) enterSafeMode() error {
 func (e *Extension) exitSafeMode() error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
-	
+
 	if !e.safeMode {
 		return nil // Not in safe mode
 	}
-	
+
 	e.safeMode = false
 	e.logger.Info("Exiting safe mode")
-	
+
 	// Reapply policy configuration
 	return e.applyPolicyConfig()
 }

--- a/test/integration/opamp_client_test.go
+++ b/test/integration/opamp_client_test.go
@@ -1,0 +1,229 @@
+package integration
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	"github.com/deepaucksharma/Phoenix/internal/extension/pic_control_ext"
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+	"github.com/deepaucksharma/Phoenix/internal/processor/adaptive_topk"
+)
+
+// generateCerts creates a CA, server, and client certificate for mTLS testing.
+func generateCerts() (caPEM, serverCertPEM, serverKeyPEM, clientCertPEM, clientKeyPEM []byte, err error) {
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return
+	}
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		DNSNames:     []string{"localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		return
+	}
+	serverCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+	serverKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		return
+	}
+	clientCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER})
+	clientKeyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)})
+	return
+}
+
+// mockOpAMPServer simulates minimal OpAMP interactions over HTTPS.
+type mockOpAMPServer struct {
+	policy []byte
+	patch  interfaces.ConfigPatch
+	mu     sync.Mutex
+	status int
+}
+
+func (s *mockOpAMPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/policy":
+		w.Header().Set("Content-Type", "application/x-yaml")
+		w.Write(s.policy)
+	case "/patch":
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(s.patch)
+	case "/status":
+		io.Copy(io.Discard, r.Body)
+		r.Body.Close()
+		s.mu.Lock()
+		s.status++
+		s.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *mockOpAMPServer) StatusCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.status
+}
+
+func TestOpAMPClientIntegration(t *testing.T) {
+	ca, srvCert, srvKey, cliCert, cliKey, err := generateCerts()
+	require.NoError(t, err)
+
+	caPool := x509.NewCertPool()
+	caPool.AppendCertsFromPEM(ca)
+
+	serverTLS, err := tls.X509KeyPair(srvCert, srvKey)
+	require.NoError(t, err)
+
+	server := &mockOpAMPServer{}
+	ts := httptest.NewUnstartedServer(server)
+	ts.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverTLS},
+		ClientCAs:    caPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+	ts.StartTLS()
+	defer ts.Close()
+
+	// Write client certs to temp files
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "ca.pem")
+	os.WriteFile(caFile, ca, 0644)
+	certFile := filepath.Join(dir, "client.pem")
+	os.WriteFile(certFile, cliCert, 0644)
+	keyFile := filepath.Join(dir, "client.key")
+	os.WriteFile(keyFile, cliKey, 0644)
+
+	// Prepare policy YAML
+	server.policy = []byte(`global_settings:
+  autonomy_level: shadow
+  collector_cpu_safety_limit_mcores: 200
+  collector_rss_safety_limit_mib: 200
+
+processors_config:
+  adaptive_topk:
+    enabled: true
+    k_value: 30
+    k_min: 10
+    k_max: 60
+
+pic_control_config:
+  policy_file_path: ""
+  max_patches_per_minute: 10
+  patch_cooldown_seconds: 1
+`)
+
+	server.patch = interfaces.ConfigPatch{
+		PatchID:             "patch1",
+		TargetProcessorName: component.MustNewID("adaptive_topk"),
+		ParameterPath:       "k_value",
+		NewValue:            40,
+		Reason:              "test",
+		Severity:            "normal",
+		Source:              "opamp",
+		Timestamp:           time.Now().Unix(),
+	}
+
+	// Build extension
+	host := &componenttest.TestHost{}
+	factory := pic_control_ext.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*pic_control_ext.Config)
+	cfg.PolicyFilePath = ""
+	cfg.OpAMPConfig = &pic_control_ext.OpAMPClientConfig{
+		ServerURL:           ts.URL,
+		InsecureSkipVerify:  false,
+		ClientCertFile:      certFile,
+		ClientKeyFile:       keyFile,
+		CACertFile:          caFile,
+		PollIntervalSeconds: 1,
+	}
+
+	ext, err := factory.CreateExtension(context.Background(), component.ExtensionCreateSettings{Logger: zap.NewNop()}, cfg)
+	require.NoError(t, err)
+
+	// Create processor
+	procFactory := adaptive_topk.NewFactory()
+	procCfg := procFactory.CreateDefaultConfig().(*adaptive_topk.Config)
+	procCfg.KValue = 30
+	procCfg.KMin = 10
+	procCfg.KMax = 60
+	procCfg.ResourceField = "process.name"
+	procCfg.CounterField = "process.cpu_seconds_total"
+	sink := new(consumertest.MetricsSink)
+	proc, err := procFactory.CreateMetricsProcessor(context.Background(), processor.CreateSettings{}, procCfg, sink)
+	require.NoError(t, err)
+
+	host.AddExtension(component.MustNewID("pic_control"), ext)
+	host.AddProcessor(component.MustNewID("adaptive_topk"), proc)
+
+	require.NoError(t, ext.Start(context.Background(), host))
+	require.NoError(t, proc.Start(context.Background(), host))
+
+	// Wait for polling
+	time.Sleep(2 * time.Second)
+
+	status, err := proc.(interfaces.UpdateableProcessor).GetConfigStatus(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 40, status.Parameters["k_value"])
+	assert.Greater(t, server.StatusCount(), 0)
+
+	ext.Shutdown(context.Background())
+	proc.Shutdown(context.Background())
+}


### PR DESCRIPTION
## Summary
- implement OpAMP client with polling support
- load policy bytes and parse in memory
- send client status and apply remote patches
- add ParsePolicy helper in policy package
- add integration test with mock OpAMP server

## Testing
- `go test ./...` *(fails: no route to host for module downloads)*