### PR TITLE
Update vendoring instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,20 @@ Phoenix uses a structured agent-based workflow where contributors take on specif
 - Document public APIs
 - Add appropriate logging and metrics
 
+## Vendoring Dependencies
+
+When adding or updating Go dependencies, the project relies on a vendored
+`vendor/` directory to ensure offline builds work consistently. After you modify
+`go.mod` or run `go get`, execute:
+
+```bash
+go mod tidy
+go mod vendor
+```
+
+Commit the resulting `vendor/` folder along with your `go.mod` and `go.sum`
+changes so that CI and other developers use the same dependency set.
+
 ## Commit Messages
 
 Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:

--- a/docs/OFFLINE_BUILD.md
+++ b/docs/OFFLINE_BUILD.md
@@ -27,6 +27,9 @@ When adding new dependencies:
    ```
 2. Commit the updated vendor directory
 
+Always rerun `go mod vendor` and commit the `vendor/` folder any time
+`go.mod` or `go.sum` changes so that offline builds stay reproducible.
+
 ## CI/CD Integration
 
 All CI workflows are configured to use the vendored dependencies, ensuring consistent builds in all environments.


### PR DESCRIPTION
## Summary
- clarify vendoring workflow in CONTRIBUTING
- highlight go mod vendor step in offline build docs

## Testing
- `make doc-writer-check` *(fails: markdownlint not installed)*