### PR TITLE
Implement integration tests and enable minimal control loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ test-unit:
 # Run integration tests only
 test-integration:
 	@echo "Running integration tests..."
-	@go test -mod=vendor -v ./test/integration/...
+	@if [ -d test/integration ]; then \
+	go test -mod=vendor -v ./test/integration/...; \
+	fi
+	@go test -mod=vendor -v ./test/e2e_tests/... ./test/extensions/...
 
 # Verify drift - Code consistency check for interdependent files
 drift-check:

--- a/test/e2e_tests/control_loop_test.go
+++ b/test/e2e_tests/control_loop_test.go
@@ -1,16 +1,101 @@
-// Package e2e contains end-to-end tests for the SA-OMF collector.
 package e2e
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/adaptive_pid"
+	"github.com/deepaucksharma/Phoenix/internal/processor/priority_tagger"
+	"github.com/deepaucksharma/Phoenix/test/testutils"
 )
 
-// TestControlLoop verifies the basic closed-loop operation of the SA-OMF system.
+// TestControlLoop sets up a minimal metrics pipeline with priority tagger and
+// adaptive PID processors to verify basic integration.
 func TestControlLoop(t *testing.T) {
-	t.Skip("Test temporarily disabled until API compatibility issues are fixed")
-	
-	// Original test implementation has been temporarily removed
-	assert.True(t, true, "Test skipped")
+	ctx := context.Background()
+
+	// Sink to receive metrics at the end of the pipeline.
+	sink := new(consumertest.MetricsSink)
+
+	// Configure adaptive PID processor.
+	pidFactory := adaptive_pid.NewFactory()
+	pidCfg := pidFactory.CreateDefaultConfig().(*adaptive_pid.Config)
+	pidCfg.Controllers = []adaptive_pid.ControllerConfig{
+		{
+			Name:              "ctrl",
+			Enabled:           true,
+			KPIMetricName:     "aemf_impact_test_metric",
+			KPITargetValue:    0.80,
+			KP:                10,
+			KI:                2,
+			KD:                0,
+			HysteresisPercent: 1,
+			OutputConfigPatches: []adaptive_pid.OutputConfigPatch{
+				{
+					TargetProcessorName: "priority_tagger",
+					ParameterPath:       "enabled",
+					ChangeScaleFactor:   0,
+					MinValue:            0,
+					MaxValue:            1,
+				},
+			},
+		},
+	}
+	pidProc, err := pidFactory.CreateMetrics(ctx, processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+		ID:                component.NewIDWithName(component.MustNewType("pid_decider"), ""),
+	}, pidCfg, sink)
+	require.NoError(t, err)
+
+	// Configure priority tagger processor.
+	taggerFactory := priority_tagger.NewFactory()
+	taggerCfg := taggerFactory.CreateDefaultConfig().(*priority_tagger.Config)
+	taggerCfg.Enabled = true
+	taggerCfg.Rules = []priority_tagger.Rule{
+		{Match: ".*", Priority: "low"},
+	}
+
+	taggerProc, err := taggerFactory.CreateMetrics(ctx, processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+		ID:                component.NewIDWithName(component.MustNewType("priority_tagger"), ""),
+	}, taggerCfg, pidProc)
+	require.NoError(t, err)
+
+	// Start processors.
+	require.NoError(t, pidProc.Start(ctx, nil))
+	require.NoError(t, taggerProc.Start(ctx, nil))
+	defer pidProc.Shutdown(ctx)
+	defer taggerProc.Shutdown(ctx)
+
+	// Create metrics containing KPI values and process attributes.
+	metrics := testutils.GenerateTestMetrics(1)
+	kpi := testutils.GenerateControlLoopMetrics(map[string]float64{"aemf_impact_test_metric": 0.5})
+	// Append KPI metrics to the first resource metrics.
+	if metrics.ResourceMetrics().Len() > 0 && kpi.ResourceMetrics().Len() > 0 {
+		src := kpi.ResourceMetrics().At(0)
+		dst := metrics.ResourceMetrics().At(0)
+		for i := 0; i < src.ScopeMetrics().Len(); i++ {
+			sm := dst.ScopeMetrics().AppendEmpty()
+			src.ScopeMetrics().At(i).CopyTo(sm)
+		}
+	}
+
+	// Execute pipeline.
+	err = taggerProc.ConsumeMetrics(ctx, metrics)
+	require.NoError(t, err)
+
+	processed := sink.AllMetrics()
+	require.NotEmpty(t, processed)
+	// Ensure a priority attribute was added by the priority tagger.
+	rm := processed[0].ResourceMetrics().At(0)
+	val, ok := rm.Resource().Attributes().Get("aemf.process.priority")
+	assert.True(t, ok)
+	assert.Equal(t, "low", val.Str())
 }

--- a/test/extensions/pic_control_ext/extension_test.go
+++ b/test/extensions/pic_control_ext/extension_test.go
@@ -1,14 +1,79 @@
 package pic_control_ext_test
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+
+	pic "github.com/deepaucksharma/Phoenix/internal/extension/pic_control_ext"
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+	"github.com/deepaucksharma/Phoenix/test/testutils"
 )
 
+func minimalPolicy(path string) string {
+	return `global_settings:
+  autonomy_level: shadow
+  collector_cpu_safety_limit_mcores: 400
+  collector_rss_safety_limit_mib: 350
+processors_config:
+  priority_tagger:
+    enabled: true
+    rules:
+      - match: ".*"
+        priority: low
+  adaptive_topk:
+    enabled: true
+    k_value: 10
+  cardinality_guardian:
+    enabled: false
+    max_unique: 100
+  reservoir_sampler:
+    enabled: false
+    reservoir_size: 100
+  others_rollup:
+    enabled: false
+pid_decider_config:
+  controllers: []
+pic_control_config:
+  policy_file_path: ` + path + `
+  max_patches_per_minute: 10
+  patch_cooldown_seconds: 0
+  safe_mode_processor_configs: {}
+service: {}`
+}
+
 func TestPicControlExtension(t *testing.T) {
-	t.Skip("Test temporarily disabled until API compatibility issues are fixed")
-	
-	// Original test implementation has been temporarily removed
-	assert.True(t, true, "Test skipped")
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	policyFile := filepath.Join(tmpDir, "policy.yaml")
+	require.NoError(t, os.WriteFile(policyFile, []byte(minimalPolicy(policyFile)), 0644))
+
+	cfg := &pic.Config{PolicyFilePath: policyFile, MaxPatchesPerMinute: 10, PatchCooldownSeconds: 0}
+	ext, err := pic.NewExtension(cfg, zap.NewNop())
+	require.NoError(t, err)
+
+	host := testutils.NewTestHost()
+	require.NoError(t, ext.Start(ctx, host))
+	defer ext.Shutdown(ctx)
+
+	// Trigger policy watcher
+	require.NoError(t, os.WriteFile(policyFile, []byte(minimalPolicy(policyFile)), 0644))
+	time.Sleep(100 * time.Millisecond)
+
+	patch := interfaces.ConfigPatch{
+		PatchID:             "test",
+		TargetProcessorName: component.NewID(component.MustNewType("priority_tagger")),
+		ParameterPath:       "enabled",
+		NewValue:            false,
+		Timestamp:           time.Now().Unix(),
+	}
+	err = ext.SubmitConfigPatch(ctx, patch)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## Summary
- add control loop e2e test exercising priority tagger and adaptive PID
- implement basic pic_control extension test
- run e2e and extension tests via `make test-integration`

## Testing
- `make test-integration`