### PR TITLE
Add processor tests using template

### DIFF
--- a/test/processors/multi_temporal_adaptive_engine/processor_test.go
+++ b/test/processors/multi_temporal_adaptive_engine/processor_test.go
@@ -1,0 +1,34 @@
+package multi_temporal_adaptive_engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/multi_temporal_adaptive_engine"
+	"github.com/deepaucksharma/Phoenix/pkg/util/timeseries"
+	processors_test "github.com/deepaucksharma/Phoenix/test/processors/templates"
+)
+
+func TestMultiTemporalAdaptiveEngineProcessor(t *testing.T) {
+	factory := multi_temporal_adaptive_engine.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*multi_temporal_adaptive_engine.Config)
+	cfg.Threshold = 2
+
+	testCases := []processors_test.ProcessorTestCase{
+		{
+			Name:         "DefaultProcessing",
+			InputMetrics: processors_test.GenerateTestMetrics([]string{"proc"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return md.ResourceMetrics().Len() == 1
+			},
+		},
+	}
+
+	processors_test.RunProcessorTests(t, factory, cfg, testCases)
+
+	data := []float64{1, 2, 3, 4, 10, 5, 6}
+	idx := timeseries.DetectZScore(data, cfg.Threshold)
+	require.Equal(t, []int{4}, idx)
+}

--- a/test/processors/semantic_correlator/processor_test.go
+++ b/test/processors/semantic_correlator/processor_test.go
@@ -1,0 +1,52 @@
+package semantic_correlator
+
+import (
+	"testing"
+
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/semantic_correlator"
+	processors_test "github.com/deepaucksharma/Phoenix/test/processors/templates"
+)
+
+func TestSemanticCorrelatorProcessor(t *testing.T) {
+	factory := semantic_correlator.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*semantic_correlator.Config)
+
+	testCases := []processors_test.ProcessorTestCase{
+		{
+			Name:         "GrangerMethod",
+			InputMetrics: processors_test.GenerateTestMetrics([]string{"proc"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return md.ResourceMetrics().Len() == 1
+			},
+			ConfigPatches: []interfaces.ConfigPatch{
+				{
+					PatchID:             "set-method",
+					TargetProcessorName: component.MustNewID("semantic_correlator"),
+					ParameterPath:       "method",
+					NewValue:            "granger",
+				},
+			},
+		},
+		{
+			Name:         "TransferEntropyMethod",
+			InputMetrics: processors_test.GenerateTestMetrics([]string{"proc"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return md.ResourceMetrics().Len() == 1
+			},
+			ConfigPatches: []interfaces.ConfigPatch{
+				{
+					PatchID:             "set-method-te",
+					TargetProcessorName: component.MustNewID("semantic_correlator"),
+					ParameterPath:       "method",
+					NewValue:            "transfer",
+				},
+			},
+		},
+	}
+
+	processors_test.RunProcessorTests(t, factory, cfg, testCases)
+}


### PR DESCRIPTION
## Summary
- add semantic correlator processor tests
- test multi temporal adaptive engine against anomaly detection utilities

## Testing
- `make test` *(fails: TestSpaceSavingSkewedDistribution)*
- `make benchmark`
