### PR TITLE
Add processor validate tests

### DIFF
--- a/test/processors/adaptive_topk/processor_test.go
+++ b/test/processors/adaptive_topk/processor_test.go
@@ -1,0 +1,81 @@
+package adaptive_topk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+	"github.com/deepaucksharma/Phoenix/internal/processor/adaptive_topk"
+	processors "github.com/deepaucksharma/Phoenix/test/processors/templates"
+)
+
+func TestValidate(t *testing.T) {
+	cfg := &adaptive_topk.Config{
+		BaseConfig:    nil,
+		KValue:        20,
+		KMin:          10,
+		KMax:          30,
+		ResourceField: "process.name",
+		CounterField:  "process.cpu_seconds_total",
+	}
+	assert.NoError(t, cfg.Validate())
+
+	cfg.KValue = 0
+	assert.Error(t, cfg.Validate())
+}
+
+func TestOnConfigPatchInvalid(t *testing.T) {
+	factory := adaptive_topk.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*adaptive_topk.Config)
+	cfg.Enabled = true
+
+	ctx := context.Background()
+	sink := new(consumertest.MetricsSink)
+	proc, err := factory.CreateMetrics(ctx, processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+		ID:                component.NewIDWithName(component.MustNewType("adaptive_topk"), ""),
+	}, cfg, sink)
+	require.NoError(t, err)
+
+	up, ok := proc.(interfaces.UpdateableProcessor)
+	require.True(t, ok)
+
+	err = proc.Start(ctx, nil)
+	require.NoError(t, err)
+
+	badPatch := interfaces.ConfigPatch{
+		PatchID:             "bad-k",
+		TargetProcessorName: component.NewIDWithName(component.MustNewType("adaptive_topk"), ""),
+		ParameterPath:       "k_value",
+		NewValue:            "invalid",
+	}
+	assert.Error(t, up.OnConfigPatch(ctx, badPatch))
+
+	require.NoError(t, proc.Shutdown(ctx))
+}
+
+func TestAdaptiveTopkProcessor(t *testing.T) {
+	factory := adaptive_topk.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*adaptive_topk.Config)
+	cfg.Enabled = true
+
+	testCases := []processors.ProcessorTestCase{
+		{
+			Name:         "Basic",
+			InputMetrics: processors.GenerateTestMetrics([]string{"p1", "p2"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return true
+			},
+		},
+	}
+
+	processors.RunProcessorTests(t, factory, cfg, testCases)
+}

--- a/test/processors/multi_temporal_adaptive_engine/processor_test.go
+++ b/test/processors/multi_temporal_adaptive_engine/processor_test.go
@@ -1,0 +1,33 @@
+package multi_temporal_adaptive_engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/multi_temporal_adaptive_engine"
+	processors "github.com/deepaucksharma/Phoenix/test/processors/templates"
+)
+
+func TestValidate(t *testing.T) {
+	cfg := &multi_temporal_adaptive_engine.Config{Enabled: true, Threshold: 2}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestMultiTemporalAdaptiveEngineProcessor(t *testing.T) {
+	factory := multi_temporal_adaptive_engine.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*multi_temporal_adaptive_engine.Config)
+
+	testCases := []processors.ProcessorTestCase{
+		{
+			Name:         "Basic",
+			InputMetrics: processors.GenerateTestMetrics([]string{"p1"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return md.ResourceMetrics().Len() == 1
+			},
+		},
+	}
+
+	processors.RunProcessorTests(t, factory, cfg, testCases)
+}

--- a/test/processors/reservoir_sampler/processor_test.go
+++ b/test/processors/reservoir_sampler/processor_test.go
@@ -1,0 +1,74 @@
+package reservoir_sampler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+	"github.com/deepaucksharma/Phoenix/internal/processor/reservoir_sampler"
+	processors "github.com/deepaucksharma/Phoenix/test/processors/templates"
+)
+
+func TestValidate(t *testing.T) {
+	cfg := &reservoir_sampler.Config{ReservoirSize: 10, Enabled: true}
+	assert.NoError(t, cfg.Validate())
+
+	cfg.ReservoirSize = 0
+	assert.Error(t, cfg.Validate())
+}
+
+func TestOnConfigPatchInvalid(t *testing.T) {
+	factory := reservoir_sampler.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*reservoir_sampler.Config)
+	cfg.Enabled = true
+
+	ctx := context.Background()
+	sink := new(consumertest.MetricsSink)
+	proc, err := factory.CreateMetrics(ctx, processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+		ID:                component.NewIDWithName(component.MustNewType("reservoir_sampler"), ""),
+	}, cfg, sink)
+	require.NoError(t, err)
+
+	up, ok := proc.(interfaces.UpdateableProcessor)
+	require.True(t, ok)
+
+	err = proc.Start(ctx, nil)
+	require.NoError(t, err)
+
+	badPatch := interfaces.ConfigPatch{
+		PatchID:             "bad-type",
+		TargetProcessorName: component.NewIDWithName(component.MustNewType("reservoir_sampler"), ""),
+		ParameterPath:       "reservoir_size",
+		NewValue:            "invalid",
+	}
+	assert.Error(t, up.OnConfigPatch(ctx, badPatch))
+
+	require.NoError(t, proc.Shutdown(ctx))
+}
+
+func TestReservoirSamplerProcessor(t *testing.T) {
+	factory := reservoir_sampler.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*reservoir_sampler.Config)
+	cfg.Enabled = true
+
+	testCases := []processors.ProcessorTestCase{
+		{
+			Name:         "PassThrough",
+			InputMetrics: processors.GenerateTestMetrics([]string{"p1", "p2"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return md.ResourceMetrics().Len() > 0
+			},
+		},
+	}
+
+	processors.RunProcessorTests(t, factory, cfg, testCases)
+}

--- a/test/processors/semantic_correlator/processor_test.go
+++ b/test/processors/semantic_correlator/processor_test.go
@@ -1,0 +1,33 @@
+package semantic_correlator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/semantic_correlator"
+	processors "github.com/deepaucksharma/Phoenix/test/processors/templates"
+)
+
+func TestValidate(t *testing.T) {
+	cfg := &semantic_correlator.Config{Enabled: true, Method: "granger", Lag: 1, Bins: 5}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestSemanticCorrelatorProcessor(t *testing.T) {
+	factory := semantic_correlator.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*semantic_correlator.Config)
+
+	testCases := []processors.ProcessorTestCase{
+		{
+			Name:         "Basic",
+			InputMetrics: processors.GenerateTestMetrics([]string{"p1"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return md.ResourceMetrics().Len() == 1
+			},
+		},
+	}
+
+	processors.RunProcessorTests(t, factory, cfg, testCases)
+}

--- a/test/processors/templates/processor_test_template.go
+++ b/test/processors/templates/processor_test_template.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/processor"
-	
+	"go.uber.org/zap"
+
 	"github.com/deepaucksharma/Phoenix/internal/interfaces"
 )
 
@@ -32,45 +33,48 @@ func RunProcessorTests(t *testing.T, factory processor.Factory, defaultConfig co
 			next := new(consumertest.MetricsSink)
 			processor, err := factory.CreateMetrics(
 				context.Background(),
-				processor.Settings{},
+				processor.Settings{
+					ID:                component.NewID(factory.Type()),
+					TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+				},
 				defaultConfig,
 				next,
 			)
 			require.NoError(t, err)
-			
+
 			// Start the processor with a no-op host
 			err = processor.Start(context.Background(), nil)
 			require.NoError(t, err)
-			
+
 			// Test updateable interface if implemented
 			if upProc, ok := processor.(interfaces.UpdateableProcessor); ok {
 				// Get initial config status
 				status, err := upProc.GetConfigStatus(context.Background())
 				require.NoError(t, err, "Failed to get initial config status")
-				
+
 				// Apply any test-specific config patches
 				for _, patch := range tc.ConfigPatches {
 					err = upProc.OnConfigPatch(context.Background(), patch)
 					require.NoError(t, err, "Failed to apply config patch: %v", err)
 				}
-				
+
 				// Verify config changes were applied
 				newStatus, err := upProc.GetConfigStatus(context.Background())
 				require.NoError(t, err, "Failed to get updated config status")
-				
+
 				// Log status changes
 				t.Logf("Config status change: %v -> %v", status.Enabled, newStatus.Enabled)
 			}
-			
+
 			// Process input metrics
 			err = processor.ConsumeMetrics(context.Background(), tc.InputMetrics)
 			require.NoError(t, err, "Failed to consume metrics: %v", err)
-			
+
 			// Verify output
 			allMetrics := next.AllMetrics()
 			require.NotEmpty(t, allMetrics, "No metrics were produced")
 			assert.True(t, tc.ExpectedOutput(allMetrics[0]), "Output metrics did not meet expectations")
-			
+
 			// Shutdown
 			err = processor.Shutdown(context.Background())
 			require.NoError(t, err, "Failed to shut down processor: %v", err)
@@ -81,27 +85,27 @@ func RunProcessorTests(t *testing.T, factory processor.Factory, defaultConfig co
 // GenerateTestMetrics creates a set of test metrics for processor testing
 func GenerateTestMetrics(processNames []string) pmetric.Metrics {
 	md := pmetric.NewMetrics()
-	
+
 	for i, procName := range processNames {
 		// Add resource metrics
 		rm := md.ResourceMetrics().AppendEmpty()
 		rm.Resource().Attributes().PutStr("process.name", procName)
 		rm.Resource().Attributes().PutStr("process.pid", fmt.Sprintf("%d", 1000+i))
-		
+
 		// Add scope metrics
 		sm := rm.ScopeMetrics().AppendEmpty()
 		sm.Scope().SetName("host")
-		
+
 		// Add CPU metric
 		cpuMetric := sm.Metrics().AppendEmpty()
 		cpuMetric.SetName("cpu.usage")
 		cpuMetric.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(float64(i) * 0.1)
-		
+
 		// Add memory metric
 		memMetric := sm.Metrics().AppendEmpty()
 		memMetric.SetName("memory.usage")
 		memMetric.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(float64(i * 100))
 	}
-	
+
 	return md
 }


### PR DESCRIPTION
## Summary
- create new test suites for missing processors
- test `Validate` and patch failure cases
- set processor ID in test template

## Testing
- `go test ./test/processors/reservoir_sampler -run . -count=1`
- `go test ./test/processors/adaptive_topk -run . -count=1`
- `go test ./test/processors/multi_temporal_adaptive_engine -run . -count=1`
- `go test ./test/processors/semantic_correlator -run . -count=1`
- `go test ./test/processors/...` *(fails: ProcessContextLearner and cardinality_guardian)*