### PR TITLE
Add processor tests using template

### DIFF
--- a/test/processors/multi_temporal_adaptive_engine/processor_test.go
+++ b/test/processors/multi_temporal_adaptive_engine/processor_test.go
@@ -1,0 +1,34 @@
+package multi_temporal_adaptive_engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/multi_temporal_adaptive_engine"
+	"github.com/deepaucksharma/Phoenix/pkg/util/timeseries"
+	processors_test "github.com/deepaucksharma/Phoenix/test/processors/templates"
+)
+
+func TestMultiTemporalAdaptiveEngineProcessor(t *testing.T) {
+	factory := multi_temporal_adaptive_engine.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*multi_temporal_adaptive_engine.Config)
+	cfg.Threshold = 2
+
+	testCases := []processors_test.ProcessorTestCase{
+		{
+			Name:         "DefaultProcessing",
+			InputMetrics: processors_test.GenerateTestMetrics([]string{"proc"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return md.ResourceMetrics().Len() == 1
+			},
+		},
+	}
+
+	processors_test.RunProcessorTests(t, factory, cfg, testCases)
+
+	data := []float64{1, 2, 3, 4, 10, 5, 6}
+	idx := timeseries.DetectZScore(data, cfg.Threshold)
+	require.Equal(t, []int{4}, idx)
+}

--- a/test/processors/semantic_correlator/processor_test.go
+++ b/test/processors/semantic_correlator/processor_test.go
@@ -1,0 +1,52 @@
+package semantic_correlator
+
+import (
+	"testing"
+
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/semantic_correlator"
+	processors_test "github.com/deepaucksharma/Phoenix/test/processors/templates"
+)
+
+func TestSemanticCorrelatorProcessor(t *testing.T) {
+	factory := semantic_correlator.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*semantic_correlator.Config)
+
+	testCases := []processors_test.ProcessorTestCase{
+		{
+			Name:         "GrangerMethod",
+			InputMetrics: processors_test.GenerateTestMetrics([]string{"proc"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return md.ResourceMetrics().Len() == 1
+			},
+			ConfigPatches: []interfaces.ConfigPatch{
+				{
+					PatchID:             "set-method",
+					TargetProcessorName: component.MustNewID("semantic_correlator"),
+					ParameterPath:       "method",
+					NewValue:            "granger",
+				},
+			},
+		},
+		{
+			Name:         "TransferEntropyMethod",
+			InputMetrics: processors_test.GenerateTestMetrics([]string{"proc"}),
+			ExpectedOutput: func(md pmetric.Metrics) bool {
+				return md.ResourceMetrics().Len() == 1
+			},
+			ConfigPatches: []interfaces.ConfigPatch{
+				{
+					PatchID:             "set-method-te",
+					TargetProcessorName: component.MustNewID("semantic_correlator"),
+					ParameterPath:       "method",
+					NewValue:            "transfer",
+				},
+			},
+		},
+	}
+
+	processors_test.RunProcessorTests(t, factory, cfg, testCases)
+}

--- a/test/processors/templates/processor_test_template.go
+++ b/test/processors/templates/processor_test_template.go
@@ -5,14 +5,14 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/processor"
-	
+
 	"github.com/deepaucksharma/Phoenix/internal/interfaces"
 )
 
@@ -32,45 +32,45 @@ func RunProcessorTests(t *testing.T, factory processor.Factory, defaultConfig co
 			next := new(consumertest.MetricsSink)
 			processor, err := factory.CreateMetrics(
 				context.Background(),
-				processor.Settings{},
+				processor.Settings{ID: component.NewID(factory.Type())},
 				defaultConfig,
 				next,
 			)
 			require.NoError(t, err)
-			
+
 			// Start the processor with a no-op host
 			err = processor.Start(context.Background(), nil)
 			require.NoError(t, err)
-			
+
 			// Test updateable interface if implemented
 			if upProc, ok := processor.(interfaces.UpdateableProcessor); ok {
 				// Get initial config status
 				status, err := upProc.GetConfigStatus(context.Background())
 				require.NoError(t, err, "Failed to get initial config status")
-				
+
 				// Apply any test-specific config patches
 				for _, patch := range tc.ConfigPatches {
 					err = upProc.OnConfigPatch(context.Background(), patch)
 					require.NoError(t, err, "Failed to apply config patch: %v", err)
 				}
-				
+
 				// Verify config changes were applied
 				newStatus, err := upProc.GetConfigStatus(context.Background())
 				require.NoError(t, err, "Failed to get updated config status")
-				
+
 				// Log status changes
 				t.Logf("Config status change: %v -> %v", status.Enabled, newStatus.Enabled)
 			}
-			
+
 			// Process input metrics
 			err = processor.ConsumeMetrics(context.Background(), tc.InputMetrics)
 			require.NoError(t, err, "Failed to consume metrics: %v", err)
-			
+
 			// Verify output
 			allMetrics := next.AllMetrics()
 			require.NotEmpty(t, allMetrics, "No metrics were produced")
 			assert.True(t, tc.ExpectedOutput(allMetrics[0]), "Output metrics did not meet expectations")
-			
+
 			// Shutdown
 			err = processor.Shutdown(context.Background())
 			require.NoError(t, err, "Failed to shut down processor: %v", err)
@@ -81,27 +81,27 @@ func RunProcessorTests(t *testing.T, factory processor.Factory, defaultConfig co
 // GenerateTestMetrics creates a set of test metrics for processor testing
 func GenerateTestMetrics(processNames []string) pmetric.Metrics {
 	md := pmetric.NewMetrics()
-	
+
 	for i, procName := range processNames {
 		// Add resource metrics
 		rm := md.ResourceMetrics().AppendEmpty()
 		rm.Resource().Attributes().PutStr("process.name", procName)
 		rm.Resource().Attributes().PutStr("process.pid", fmt.Sprintf("%d", 1000+i))
-		
+
 		// Add scope metrics
 		sm := rm.ScopeMetrics().AppendEmpty()
 		sm.Scope().SetName("host")
-		
+
 		// Add CPU metric
 		cpuMetric := sm.Metrics().AppendEmpty()
 		cpuMetric.SetName("cpu.usage")
 		cpuMetric.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(float64(i) * 0.1)
-		
+
 		// Add memory metric
 		memMetric := sm.Metrics().AppendEmpty()
 		memMetric.SetName("memory.usage")
 		memMetric.SetEmptyGauge().DataPoints().AppendEmpty().SetDoubleValue(float64(i * 100))
 	}
-	
+
 	return md
 }


### PR DESCRIPTION
## Summary
- add semantic correlator processor tests
- test multi temporal adaptive engine against anomaly detection utilities
- fix processor test template to set component ID

## Testing
- `make test` *(fails: TestSpaceSavingSkewedDistribution)*
- `make benchmark`
