### PR TITLE
Align Go version to 1.22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.24
+FROM mcr.microsoft.com/devcontainers/go:1.22
 
 ARG USERNAME=vscode
 ARG USER_UID=1000

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   timeout: 5m
   modules-download-mode: readonly
-  go: '1.24'
+  go: '1.22'
 
 linters:
   enable:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,7 +343,7 @@ The system includes several safety mechanisms:
 
 ### Prerequisites
 
-- Go 1.24 or higher
+- Go 1.22 or higher
 - OpenTelemetry Collector Contrib
 - Docker (for containerized testing)
 - Kubernetes (optional, for orchestrated deployment)

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -45,7 +45,7 @@ This document defines the roles, responsibilities, and boundaries for agents and
 
 ## Technical Standards
 
-- Go version: 1.24+
+- Go version: 1.22+
 - Code style: Follow `golangci-lint` rules
 - Commit style: [Conventional Commits](https://www.conventionalcommits.org/)
 - PR process: Create branch → Implement → CI checks → Review → Merge

--- a/agents/CONSOLIDATED_AGENTS.md
+++ b/agents/CONSOLIDATED_AGENTS.md
@@ -464,7 +464,7 @@ The Phoenix system must balance data completeness (coverage) against performance
 
 ## Technical Standards
 
-- Go version: 1.24+
+- Go version: 1.22+
 - Code style: Follow `golangci-lint` rules
 - Test coverage: Maintain above 60%
 - Documentation: All public APIs must be documented


### PR DESCRIPTION
## Summary
- update golangci config to Go 1.22
- sync devcontainer image with Go 1.22
- refresh documentation for Go 1.22

## Testing
- `make verify` *(fails: unable to download golangci-lint)*
- `make test` *(fails: TestSpaceSavingSkewedDistribution)*