### PR TITLE
Fix ADR path references

### DIFF
--- a/agents/architect.yaml
+++ b/agents/architect.yaml
@@ -5,11 +5,11 @@ required_checks:
   - lint
   - adr-valid
 can_touch:
-  - docs/adr/**
+  - docs/architecture/adr/**
   - docs/architecture/**
   - docs/design/**
 must_touch:
-  - docs/adr/**
+  - docs/architecture/adr/**
 blocked_files:
   - cmd/**
   - internal/**

--- a/docs/adr
+++ b/docs/adr
@@ -1,0 +1,1 @@
+architecture/adr

--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -16,7 +16,7 @@ Architecture Decision Records are documents that capture important architectural
 Use the script in the repository to create a new ADR:
 
 ```bash
-./hack/new-adr.sh "Title of the ADR"
+./scripts/dev/new-adr.sh "Title of the ADR"
 ```
 
 This will create a new ADR with the correct format and naming convention.

--- a/scripts/dev/new-adr.sh
+++ b/scripts/dev/new-adr.sh
@@ -12,7 +12,7 @@ fi
 TITLE=$1
 DATE=$(date +%Y%m%d)
 FILENAME="${DATE}-$(echo $TITLE | tr '[:upper:]' '[:lower:]' | tr ' ' '-').md"
-FULLPATH="docs/adr/$FILENAME"
+FULLPATH="docs/architecture/adr/$FILENAME"
 
 # Check if file already exists
 

--- a/scripts/dev/validate-adr.sh
+++ b/scripts/dev/validate-adr.sh
@@ -5,7 +5,7 @@ set -e
 
 # Find all ADR files
 
-ADR_FILES=$(find docs/adr -name "*.md")
+ADR_FILES=$(find docs/architecture/adr -name "*.md")
 
 # Check each ADR
 


### PR DESCRIPTION
## Summary
- update architect policy for new ADR path
- point ADR scripts at `docs/architecture/adr`
- fix documentation to show the new script location
- add backward compatible `docs/adr` symlink

## Testing
- `make lint` *(fails: golangci-lint download blocked)*
- `make test` *(fails: TestSpaceSavingSkewedDistribution)*