### PR TITLE
Implement processor discovery in pic_control_ext

### DIFF
--- a/internal/extension/pic_control_ext/extension.go
+++ b/internal/extension/pic_control_ext/extension.go
@@ -198,18 +198,34 @@ func (e *Extension) registerProcessors() error {
 		return fmt.Errorf("host not initialized")
 	}
 
-	// Note: The current implementation doesn't provide direct access to processors
-	// We'll use a placeholder method to simulate processor discovery
-	// This would be replaced with actual processor discovery in a production environment
-	
-	// Find processors from the host - this simulated code must be updated when a real solution
-	// for processor discovery is implemented
-	testProcessors := map[component.ID]interfaces.UpdateableProcessor{}
-	
-	// Simulated processors for testing
-	for id, proc := range testProcessors {
+	// Host may implement an additional interface exposing processors
+	type processorGetter interface {
+		GetProcessors() map[component.ID]component.Component
+	}
+
+	getter, ok := e.host.(processorGetter)
+	if !ok {
+		return fmt.Errorf("host does not expose processors")
+	}
+
+	processors := getter.GetProcessors()
+	if len(processors) == 0 {
+		e.logger.Warn("no processors found on host")
+	}
+
+	for id, comp := range processors {
+		proc, ok := comp.(interfaces.UpdateableProcessor)
+		if !ok {
+			e.logger.Debug("processor does not implement UpdateableProcessor", zap.String("id", id.String()))
+			continue
+		}
+
 		e.processors[id] = proc
 		e.logger.Info("Registered updateable processor", zap.String("id", id.String()))
+	}
+
+	if len(e.processors) == 0 {
+		return fmt.Errorf("no UpdateableProcessor components discovered")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- replace placeholder processor registration logic
- discover UpdateableProcessors from the host via `GetProcessors`
- log and return errors when processors cannot be found

## Testing
- `make lint` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*
- `make test` *(fails: TestSpaceSavingSkewedDistribution)*