### PR TITLE
Add sample Docker Compose test environments

### DIFF
--- a/docs/testing/validation-framework.md
+++ b/docs/testing/validation-framework.md
@@ -17,6 +17,8 @@ This ultra-detailed testing framework provides a comprehensive approach to valid
 
 ```bash
 # Create test environments with Docker Compose
+# Example compose files are provided in `test-environments/*`.
+# Run the following commands if you need to recreate them manually.
 mkdir -p test-environments/{bare,prometheus,full}
 
 # Bare Environment (just the collector)

--- a/test-environments/bare/config.yaml
+++ b/test-environments/bare/config.yaml
@@ -1,0 +1,1 @@
+../../configs/examples/config.yaml

--- a/test-environments/bare/docker-compose.yaml
+++ b/test-environments/bare/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  sa-omf-collector:
+    image: yourorg/sa-omf-collector:latest
+    build: ../../
+    volumes:
+      - ./config.yaml:/etc/sa-omf/config.yaml
+      - ./policy.yaml:/etc/sa-omf/policy.yaml
+      - /proc:/proc:ro
+      - /sys:/sys:ro
+    ports:
+      - "8888:8888"
+      - "13133:13133"

--- a/test-environments/bare/policy.yaml
+++ b/test-environments/bare/policy.yaml
@@ -1,0 +1,1 @@
+../../configs/examples/policy.yaml

--- a/test-environments/full/config.yaml
+++ b/test-environments/full/config.yaml
@@ -1,0 +1,1 @@
+../../configs/examples/config.yaml

--- a/test-environments/full/docker-compose.yaml
+++ b/test-environments/full/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: '3'
+services:
+  sa-omf-collector:
+    image: yourorg/sa-omf-collector:latest
+    build: ../../
+    volumes:
+      - ./config.yaml:/etc/sa-omf/config.yaml
+      - ./policy.yaml:/etc/sa-omf/policy.yaml
+      - /proc:/proc:ro
+      - /sys:/sys:ro
+    ports:
+      - "8888:8888"
+      - "13133:13133"
+  prometheus:
+    image: prom/prometheus:v2.48.0
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana:10.2.0
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ../../dashboards:/var/lib/grafana/dashboards
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - "3000:3000"

--- a/test-environments/full/policy.yaml
+++ b/test-environments/full/policy.yaml
@@ -1,0 +1,1 @@
+../../configs/examples/policy.yaml

--- a/test-environments/prometheus/config.yaml
+++ b/test-environments/prometheus/config.yaml
@@ -1,0 +1,1 @@
+../../configs/examples/config.yaml

--- a/test-environments/prometheus/docker-compose.yaml
+++ b/test-environments/prometheus/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  sa-omf-collector:
+    image: yourorg/sa-omf-collector:latest
+    build: ../../
+    volumes:
+      - ./config.yaml:/etc/sa-omf/config.yaml
+      - ./policy.yaml:/etc/sa-omf/policy.yaml
+      - /proc:/proc:ro
+      - /sys:/sys:ro
+    ports:
+      - "8888:8888"
+      - "13133:13133"
+  prometheus:
+    image: prom/prometheus:v2.48.0
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"

--- a/test-environments/prometheus/policy.yaml
+++ b/test-environments/prometheus/policy.yaml
@@ -1,0 +1,1 @@
+../../configs/examples/policy.yaml

--- a/test/README.md
+++ b/test/README.md
@@ -124,3 +124,10 @@ metrics := testutils.GenerateTestMetrics(10, 5) // 10 resources, 5 metrics each
 ## Test Templates
 
 Processor tests should follow the templates in `processors/templates/` to ensure consistency across all processor implementations.
+
+## Manual Test Environments
+
+Sample Docker Compose setups are provided in the repository under `../test-environments`.
+These configurations match the examples in the validation framework and can be
+used to manually spin up the collector with optional Prometheus and Grafana
+services for local experimentation.


### PR DESCRIPTION
## Summary
- provide example `docker-compose.yaml` files for bare, prometheus and full setups
- document that `test-environments` is prepopulated
- mention manual env location in testing README

## Testing
- `make lint` *(fails: no route to host for Go module download)*
- `make test-unit` *(fails: several unit tests failed)*
- `make test-coverage` *(fails: unit tests failed)*
- `make drift-check` *(fails: missing check_component_registry.sh)*