### PR TITLE
Add scenario placeholders and update integration tooling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run integration tests
         if: github.event_name != 'pull_request'
         run: |
-          go test -mod=vendor -race -v ./test/integration/...
+          go test -mod=vendor -race -v ./test/e2e/...
 
       # Check for code consistency
       - name: Drift check
@@ -76,6 +76,37 @@ jobs:
       - name: Run benchmarks
         run: go test -mod=vendor -run=^$ -bench=. -benchmem ./...
         continue-on-error: true
+
+  scenario-tests:
+    name: Scenario ${{ matrix.scenario }}
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      matrix:
+        scenario: [BOOT-01, PIPE-03, CHAOS-CPU]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - name: Run scenario tests
+        run: |
+          case "${{ matrix.scenario }}" in
+            BOOT-01)
+              go test -mod=vendor -run TestBoot01 ./test/e2e/integration
+              ;;
+            PIPE-03)
+              go test -mod=vendor -run TestPipe03 ./test/e2e/integration
+              ;;
+            CHAOS-CPU)
+              go test -mod=vendor -run TestChaosCPU ./test/e2e/benchmarks
+              ;;
+          esac
 
   # Security scanning with CodeQL
   security:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-unit:
 # Run integration tests only
 test-integration:
 	@echo "Running integration tests..."
-	@$(GO_OFFLINE_ENV) go test $(GO_TEST_FLAGS) ./test/integration/...
+	@$(GO_OFFLINE_ENV) go test $(GO_TEST_FLAGS) ./test/e2e/...
 
 # Run tests with coverage
 test-coverage:

--- a/test/e2e/benchmarks/chaos_cpu_test.go
+++ b/test/e2e/benchmarks/chaos_cpu_test.go
@@ -1,0 +1,18 @@
+// Scenario: CHAOS-CPU
+package benchmark
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/deepaucksharma/Phoenix/test/testutils"
+)
+
+func TestChaosCPU(t *testing.T) {
+	t.Skip("Scenario temporarily disabled")
+
+	_ = testutils.GenerateTestMetrics(1)
+
+	cmd := exec.Command("go", "run", "test/generator/workload.go", "--processes", "100", "--spike-freq", "1.0", "--duration", "1s")
+	_ = cmd
+}

--- a/test/e2e/benchmarks/priority_tagger_benchmark_test.go
+++ b/test/e2e/benchmarks/priority_tagger_benchmark_test.go
@@ -8,7 +8,7 @@ import (
 
 func BenchmarkPriorityTaggerEndToEnd(b *testing.B) {
 	b.Skip("Test temporarily disabled until API compatibility issues are fixed")
-	
+
 	// Original test implementation has been temporarily removed
 	assert.True(b, true, "Test skipped")
 }

--- a/test/e2e/integration/boot_01_test.go
+++ b/test/e2e/integration/boot_01_test.go
@@ -1,0 +1,18 @@
+// Scenario: BOOT-01
+package e2e
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/deepaucksharma/Phoenix/test/testutils"
+)
+
+func TestBoot01(t *testing.T) {
+	t.Skip("Scenario temporarily disabled")
+
+	_ = testutils.GenerateMetrics()
+
+	cmd := exec.Command("go", "run", "test/generator/workload.go", "--duration", "1s")
+	_ = cmd
+}

--- a/test/e2e/integration/control_loop_test.go
+++ b/test/e2e/integration/control_loop_test.go
@@ -10,7 +10,7 @@ import (
 // TestControlLoop verifies the basic closed-loop operation of the SA-OMF system.
 func TestControlLoop(t *testing.T) {
 	t.Skip("Test temporarily disabled until API compatibility issues are fixed")
-	
+
 	// Original test implementation has been temporarily removed
 	assert.True(t, true, "Test skipped")
 }

--- a/test/e2e/integration/pipe_03_test.go
+++ b/test/e2e/integration/pipe_03_test.go
@@ -1,0 +1,14 @@
+// Scenario: PIPE-03
+package e2e
+
+import (
+	"testing"
+
+	"github.com/deepaucksharma/Phoenix/test/testutils"
+)
+
+func TestPipe03(t *testing.T) {
+	t.Skip("Scenario temporarily disabled")
+
+	_ = testutils.GenerateHighCardinalityMetrics(5)
+}


### PR DESCRIPTION
## Summary
- add placeholder scenario tests for BOOT-01, PIPE-03 and CHAOS-CPU
- run integration tests from `test/e2e` via Makefile
- execute scenario tests in CI matrix

## Testing
- `make test-integration` *(fails: inconsistent vendoring)*