### PR TITLE
Align otel deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.opentelemetry.io/collector/component v1.32.0
 	go.opentelemetry.io/collector/consumer v1.32.0
-	go.opentelemetry.io/collector/consumer/consumertest v0.126.0
-	go.opentelemetry.io/collector/exporter v0.126.0
+	go.opentelemetry.io/collector/consumer/consumertest v1.32.0
+	go.opentelemetry.io/collector/exporter v1.32.0
 	go.opentelemetry.io/collector/extension v1.32.0
-	go.opentelemetry.io/collector/otelcol v0.126.0
+	go.opentelemetry.io/collector/otelcol v1.32.0
 	go.opentelemetry.io/collector/pdata v1.32.0
 	go.opentelemetry.io/collector/processor v1.32.0
 	go.opentelemetry.io/collector/receiver v1.32.0
@@ -71,33 +71,33 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/component/componentstatus v0.126.0 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.126.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.126.0 // indirect
+	go.opentelemetry.io/collector/component/componentstatus v1.32.0 // indirect
+	go.opentelemetry.io/collector/component/componenttest v1.32.0 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v1.32.0 // indirect
 	go.opentelemetry.io/collector/confmap v1.32.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.126.0 // indirect
-	go.opentelemetry.io/collector/connector v0.126.0 // indirect
-	go.opentelemetry.io/collector/connector/connectortest v0.126.0 // indirect
-	go.opentelemetry.io/collector/connector/xconnector v0.126.0 // indirect
-	go.opentelemetry.io/collector/consumer/consumererror v0.126.0 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.126.0 // indirect
-	go.opentelemetry.io/collector/exporter/exportertest v0.126.0 // indirect
-	go.opentelemetry.io/collector/exporter/xexporter v0.126.0 // indirect
-	go.opentelemetry.io/collector/extension/extensioncapabilities v0.126.0 // indirect
-	go.opentelemetry.io/collector/extension/extensiontest v0.126.0 // indirect
+	go.opentelemetry.io/collector/confmap/xconfmap v1.32.0 // indirect
+	go.opentelemetry.io/collector/connector v1.32.0 // indirect
+	go.opentelemetry.io/collector/connector/connectortest v1.32.0 // indirect
+	go.opentelemetry.io/collector/connector/xconnector v1.32.0 // indirect
+	go.opentelemetry.io/collector/consumer/consumererror v1.32.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v1.32.0 // indirect
+	go.opentelemetry.io/collector/exporter/exportertest v1.32.0 // indirect
+	go.opentelemetry.io/collector/exporter/xexporter v1.32.0 // indirect
+	go.opentelemetry.io/collector/extension/extensioncapabilities v1.32.0 // indirect
+	go.opentelemetry.io/collector/extension/extensiontest v1.32.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.32.0 // indirect
-	go.opentelemetry.io/collector/internal/fanoutconsumer v0.126.0 // indirect
-	go.opentelemetry.io/collector/internal/telemetry v0.126.0 // indirect
-	go.opentelemetry.io/collector/pdata/pprofile v0.126.0 // indirect
-	go.opentelemetry.io/collector/pdata/testdata v0.126.0 // indirect
-	go.opentelemetry.io/collector/pipeline v0.126.0 // indirect
-	go.opentelemetry.io/collector/pipeline/xpipeline v0.126.0 // indirect
-	go.opentelemetry.io/collector/processor/processortest v0.126.0 // indirect
-	go.opentelemetry.io/collector/processor/xprocessor v0.126.0 // indirect
-	go.opentelemetry.io/collector/receiver/receivertest v0.126.0 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.126.0 // indirect
-	go.opentelemetry.io/collector/service v0.126.0 // indirect
-	go.opentelemetry.io/collector/service/hostcapabilities v0.126.0 // indirect
+	go.opentelemetry.io/collector/internal/fanoutconsumer v1.32.0 // indirect
+	go.opentelemetry.io/collector/internal/telemetry v1.32.0 // indirect
+	go.opentelemetry.io/collector/pdata/pprofile v1.32.0 // indirect
+	go.opentelemetry.io/collector/pdata/testdata v1.32.0 // indirect
+	go.opentelemetry.io/collector/pipeline v1.32.0 // indirect
+	go.opentelemetry.io/collector/pipeline/xpipeline v1.32.0 // indirect
+	go.opentelemetry.io/collector/processor/processortest v1.32.0 // indirect
+	go.opentelemetry.io/collector/processor/xprocessor v1.32.0 // indirect
+	go.opentelemetry.io/collector/receiver/receivertest v1.32.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v1.32.0 // indirect
+	go.opentelemetry.io/collector/service v1.32.0 // indirect
+	go.opentelemetry.io/collector/service/hostcapabilities v1.32.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.10.0 // indirect
 	go.opentelemetry.io/contrib/otelconf v0.15.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.35.0 // indirect


### PR DESCRIPTION
## Summary
- align go.opentelemetry.io/collector modules to `v1.32.0`

## Testing
- `go mod tidy` *(fails: proxyconnect tcp: dial tcp 172.27.0.3:8080: connect: no route to host)*
- `go mod vendor` *(fails: proxyconnect tcp: dial tcp 172.27.0.3:8080: connect: no route to host)*