### PR TITLE
Improve config patch validation

### DIFF
--- a/internal/processor/priority_tagger/processor.go
+++ b/internal/processor/priority_tagger/processor.go
@@ -3,6 +3,7 @@ package priority_tagger
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"sync"
 
@@ -149,7 +150,7 @@ func (p *processorImp) OnConfigPatch(ctx context.Context, patch interfaces.Confi
 		// Update enabled flag
 		enabled, ok := patch.NewValue.(bool)
 		if !ok {
-			return nil
+			return fmt.Errorf("invalid type for enabled: %T", patch.NewValue)
 		}
 		p.config.Enabled = enabled
 		return nil
@@ -158,7 +159,7 @@ func (p *processorImp) OnConfigPatch(ctx context.Context, patch interfaces.Confi
 		// Update rules
 		rules, ok := patch.NewValue.([]Rule)
 		if !ok {
-			return nil
+			return fmt.Errorf("invalid type for rules: %T", patch.NewValue)
 		}
 
 		// Reset rules

--- a/test/processors/priority_tagger/processor_test.go
+++ b/test/processors/priority_tagger/processor_test.go
@@ -128,6 +128,24 @@ func TestPriorityTaggerProcessor(t *testing.T) {
 	err = updateableProc.OnConfigPatch(ctx, invalidPatch)
 	assert.Error(t, err, "Should fail with invalid regex")
 
+	// Invalid type for enabled
+	badEnable := interfaces.ConfigPatch{
+		PatchID:             "bad-enable",
+		TargetProcessorName: component.NewIDWithName(component.MustNewType("priority_tagger"), ""),
+		ParameterPath:       "enabled",
+		NewValue:            "true",
+	}
+	assert.Error(t, updateableProc.OnConfigPatch(ctx, badEnable))
+
+	// Invalid type for rules
+	badRules := interfaces.ConfigPatch{
+		PatchID:             "bad-rules",
+		TargetProcessorName: component.NewIDWithName(component.MustNewType("priority_tagger"), ""),
+		ParameterPath:       "rules",
+		NewValue:            "not-a-slice",
+	}
+	assert.Error(t, updateableProc.OnConfigPatch(ctx, badRules))
+
 	// Test actual metric processing functionality
 	t.Run("ProcessMetrics", func(t *testing.T) {
 		// Create test metrics


### PR DESCRIPTION
## Summary
- check patch value types in priority_tagger
- expect bad-type errors in priority_tagger tests

## Testing
- `go test ./...` *(fails: download toolchain no route to host)*