### PR TITLE
Initialize Go module with placeholders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/deepaucksharma/Phoenix
+
+go 1.23.8

--- a/internal/connector/pic_connector/factory.go
+++ b/internal/connector/pic_connector/factory.go
@@ -1,0 +1,29 @@
+package pic_connector
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const Type = "pic_connector"
+
+type Config struct{}
+
+func createDefaultConfig() component.Config { return &Config{} }
+
+func NewFactory() exporter.Factory {
+	return exporter.NewFactory(
+		Type,
+		createDefaultConfig,
+		exporter.WithMetrics(createMetricsExporter, component.StabilityLevelAlpha),
+	)
+}
+
+func createMetricsExporter(ctx context.Context, set exporter.CreateSettings, cfg component.Config) (exporter.Metrics, error) {
+	consume := func(ctx context.Context, md pmetric.Metrics) error { return nil }
+	return exporterhelper.NewMetricsExporter(ctx, set, cfg, consume)
+}

--- a/internal/control/configpatch/validator.go
+++ b/internal/control/configpatch/validator.go
@@ -1,0 +1,28 @@
+package configpatch
+
+import (
+	"sync"
+
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+)
+
+type Options struct {
+	AllowedSeverityLevels []string
+	AllowedSources        []string
+	MaxPatchesPerMinute   int
+	PatchCooldownSeconds  int
+}
+
+type StandardValidator struct {
+	mu      sync.Mutex
+	history []interfaces.ConfigPatch
+	opts    *Options
+}
+
+func NewStandardValidator(opts *Options) *StandardValidator {
+	return &StandardValidator{opts: opts}
+}
+
+func (v *StandardValidator) Validate(patch interfaces.ConfigPatch) error { return nil }
+func (v *StandardValidator) GetHistory() []interfaces.ConfigPatch        { return v.history }
+func (v *StandardValidator) Reset()                                      { v.history = nil }

--- a/internal/processor/adaptive_topk/factory.go
+++ b/internal/processor/adaptive_topk/factory.go
@@ -1,0 +1,37 @@
+package adaptive_topk
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+const Type = "adaptive_topk"
+
+type Config struct {
+	KValue         int     `mapstructure:"k_value"`
+	KMin           int     `mapstructure:"k_min"`
+	KMax           int     `mapstructure:"k_max"`
+	ResourceField  string  `mapstructure:"resource_field"`
+	CounterField   string  `mapstructure:"counter_field"`
+	CoverageTarget float64 `mapstructure:"coverage_target"`
+}
+
+func createDefaultConfig() component.Config { return &Config{} }
+
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		Type,
+		createDefaultConfig,
+		processor.WithMetrics(createMetricsProcessor, component.StabilityLevelAlpha),
+	)
+}
+
+func createMetricsProcessor(ctx context.Context, set processor.CreateSettings, cfg component.Config, next consumer.Metrics) (processor.Metrics, error) {
+	process := func(ctx context.Context, md pmetric.Metrics) (pmetric.Metrics, error) { return md, nil }
+	return processorhelper.NewMetricsProcessor(ctx, set, cfg, next, process)
+}

--- a/internal/processor/others_rollup/factory.go
+++ b/internal/processor/others_rollup/factory.go
@@ -1,0 +1,35 @@
+package others_rollup
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+const Type = "others_rollup"
+
+type Config struct {
+	Enabled           bool   `mapstructure:"enabled"`
+	PriorityThreshold string `mapstructure:"priority_threshold"`
+	Strategy          string `mapstructure:"strategy"`
+	NamePrefix        string `mapstructure:"name_prefix"`
+}
+
+func createDefaultConfig() component.Config { return &Config{} }
+
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		Type,
+		createDefaultConfig,
+		processor.WithMetrics(createMetricsProcessor, component.StabilityLevelAlpha),
+	)
+}
+
+func createMetricsProcessor(ctx context.Context, set processor.CreateSettings, cfg component.Config, next consumer.Metrics) (processor.Metrics, error) {
+	process := func(ctx context.Context, md pmetric.Metrics) (pmetric.Metrics, error) { return md, nil }
+	return processorhelper.NewMetricsProcessor(ctx, set, cfg, next, process)
+}

--- a/internal/processor/priority_tagger/factory.go
+++ b/internal/processor/priority_tagger/factory.go
@@ -1,0 +1,37 @@
+package priority_tagger
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+const Type = "priority_tagger"
+
+type Rule struct {
+	Match    string `mapstructure:"match"`
+	Priority string `mapstructure:"priority"`
+}
+
+type Config struct {
+	Rules []Rule `mapstructure:"rules"`
+}
+
+func createDefaultConfig() component.Config { return &Config{} }
+
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		Type,
+		createDefaultConfig,
+		processor.WithMetrics(createMetricsProcessor, component.StabilityLevelAlpha),
+	)
+}
+
+func createMetricsProcessor(ctx context.Context, set processor.CreateSettings, cfg component.Config, next consumer.Metrics) (processor.Metrics, error) {
+	process := func(ctx context.Context, md pmetric.Metrics) (pmetric.Metrics, error) { return md, nil }
+	return processorhelper.NewMetricsProcessor(ctx, set, cfg, next, process)
+}

--- a/internal/processor/reservoir_sampler/factory.go
+++ b/internal/processor/reservoir_sampler/factory.go
@@ -1,0 +1,30 @@
+package reservoir_sampler
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+const Type = "reservoir_sampler"
+
+type Config struct{}
+
+func createDefaultConfig() component.Config { return &Config{} }
+
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		Type,
+		createDefaultConfig,
+		processor.WithMetrics(createMetricsProcessor, component.StabilityLevelAlpha),
+	)
+}
+
+func createMetricsProcessor(ctx context.Context, set processor.CreateSettings, cfg component.Config, next consumer.Metrics) (processor.Metrics, error) {
+	process := func(ctx context.Context, md pmetric.Metrics) (pmetric.Metrics, error) { return md, nil }
+	return processorhelper.NewMetricsProcessor(ctx, set, cfg, next, process)
+}

--- a/internal/processor/resource_filter/types.go
+++ b/internal/processor/resource_filter/types.go
@@ -1,0 +1,65 @@
+package resource_filter
+
+// FilterStrategy defines the strategy used for filtering resources.
+type FilterStrategy string
+
+const (
+	StrategyPriority FilterStrategy = "priority"
+	StrategyTopK     FilterStrategy = "topk"
+	StrategyHybrid   FilterStrategy = "hybrid"
+)
+
+// PriorityLevel indicates the importance of a resource.
+type PriorityLevel string
+
+const (
+	PriorityCritical PriorityLevel = "critical"
+	PriorityHigh     PriorityLevel = "high"
+	PriorityMedium   PriorityLevel = "medium"
+	PriorityLow      PriorityLevel = "low"
+)
+
+// AggregationType defines rollup aggregation behavior.
+type AggregationType string
+
+const (
+	AggregationSum AggregationType = "sum"
+	AggregationAvg AggregationType = "avg"
+)
+
+// PriorityRule maps a match expression to a priority level.
+type PriorityRule struct {
+	Match    string        `mapstructure:"match"`
+	Priority PriorityLevel `mapstructure:"priority"`
+}
+
+// TopKConfig configures the top-k strategy.
+type TopKConfig struct {
+	KValue         int     `mapstructure:"k_value"`
+	KMin           int     `mapstructure:"k_min"`
+	KMax           int     `mapstructure:"k_max"`
+	ResourceField  string  `mapstructure:"resource_field"`
+	CounterField   string  `mapstructure:"counter_field"`
+	CoverageTarget float64 `mapstructure:"coverage_target"`
+}
+
+// RollupConfig controls rollup aggregation of low priority metrics.
+type RollupConfig struct {
+	Enabled           bool            `mapstructure:"enabled"`
+	PriorityThreshold PriorityLevel   `mapstructure:"priority_threshold"`
+	Strategy          AggregationType `mapstructure:"strategy"`
+	NamePrefix        string          `mapstructure:"name_prefix"`
+}
+
+// Config holds the full filter configuration.
+type Config struct {
+	Enabled           bool           `mapstructure:"enabled"`
+	FilterStrategy    FilterStrategy `mapstructure:"filter_strategy"`
+	PriorityAttribute string         `mapstructure:"priority_attribute"`
+	PriorityRules     []PriorityRule `mapstructure:"priority_rules"`
+	TopK              TopKConfig     `mapstructure:"topk"`
+	Rollup            RollupConfig   `mapstructure:"rollup"`
+}
+
+// Validate validates the configuration. This stub always returns nil.
+func (c *Config) Validate() error { return nil }


### PR DESCRIPTION
## Summary
- initialize a basic `go.mod` file
- add placeholder processor/exporter/validator packages so `go mod tidy` can run offline

## Testing
- `make build` *(fails: import lookup disabled by -mod=vendor)*
- `make vendor` *(fails: no required module provides packages)*
- `make test` *(fails: import lookup disabled by -mod=vendor)*