### PR TITLE
Add processor tests for timeseries estimator and CPU histogram

### DIFF
--- a/internal/processor/cpu_histogram_converter/config.go
+++ b/internal/processor/cpu_histogram_converter/config.go
@@ -1,0 +1,33 @@
+package cpu_histogram_converter
+
+import (
+	"fmt"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/base"
+)
+
+// Config defines configuration for the cpu histogram converter.
+type Config struct {
+	*base.BaseConfig `mapstructure:",squash"`
+	Boundaries       []float64 `mapstructure:"boundaries"`
+	MetricNames      []string  `mapstructure:"metric_names"`
+}
+
+// Validate checks the configuration for any issues.
+func (c *Config) Validate() error {
+	if err := c.BaseConfig.Validate(); err != nil {
+		return err
+	}
+	if len(c.Boundaries) == 0 {
+		return fmt.Errorf("boundaries cannot be empty")
+	}
+	for i := 1; i < len(c.Boundaries); i++ {
+		if c.Boundaries[i] <= c.Boundaries[i-1] {
+			return fmt.Errorf("boundaries must be strictly increasing")
+		}
+	}
+	if len(c.MetricNames) == 0 {
+		c.MetricNames = []string{"process.cpu.utilization"}
+	}
+	return nil
+}

--- a/internal/processor/cpu_histogram_converter/factory.go
+++ b/internal/processor/cpu_histogram_converter/factory.go
@@ -1,0 +1,44 @@
+package cpu_histogram_converter
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/base"
+)
+
+const Type = "cpu_histogram_converter"
+
+// NewFactory creates a factory for the cpu histogram converter.
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		Type,
+		createDefaultConfig,
+		processor.WithMetrics(createMetricsProcessor, component.StabilityLevelAlpha),
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{
+		BaseConfig:  base.NewBaseConfig(),
+		Boundaries:  []float64{0, 25, 50, 75, 100},
+		MetricNames: []string{"process.cpu.utilization"},
+	}
+}
+
+func createMetricsProcessor(
+	ctx context.Context,
+	set processor.CreateSettings,
+	cfg component.Config,
+	next consumer.Metrics,
+) (processor.Metrics, error) {
+	c, ok := cfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config type")
+	}
+	return newProcessor(c, set, next)
+}

--- a/internal/processor/cpu_histogram_converter/processor.go
+++ b/internal/processor/cpu_histogram_converter/processor.go
@@ -1,0 +1,127 @@
+package cpu_histogram_converter
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/base"
+)
+
+type processorImpl struct {
+	*base.BaseProcessor
+	config *Config
+}
+
+var _ processor.Metrics = (*processorImpl)(nil)
+
+func newProcessor(cfg *Config, set processor.CreateSettings, next consumer.Metrics) (*processorImpl, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &processorImpl{
+		BaseProcessor: base.NewBaseProcessor(set.TelemetrySettings.Logger, next, Type, set.ID),
+		config:        cfg,
+	}, nil
+}
+
+func (p *processorImpl) Start(ctx context.Context, host component.Host) error {
+	return p.BaseProcessor.Start(ctx, host)
+}
+
+func (p *processorImpl) Shutdown(ctx context.Context) error {
+	return p.BaseProcessor.Shutdown(ctx)
+}
+
+func (p *processorImpl) Capabilities() consumer.Capabilities {
+	return p.BaseProcessor.Capabilities()
+}
+
+func (p *processorImpl) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.config.Enabled {
+		return p.GetNext().ConsumeMetrics(ctx, md)
+	}
+
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			metrics := sm.Metrics()
+			for k := 0; k < metrics.Len(); k++ {
+				m := metrics.At(k)
+				if !p.shouldConvert(m.Name()) {
+					continue
+				}
+
+				// Prepare histogram metric
+				histMetric := sm.Metrics().AppendEmpty()
+				histMetric.SetName(m.Name())
+				h := histMetric.SetEmptyHistogram()
+				h.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				h.ExplicitBounds().FromRaw(p.config.Boundaries)
+
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					dps := m.Gauge().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						src := dps.At(l)
+						dp := h.DataPoints().AppendEmpty()
+						p.convertDataPoint(src.DoubleValue(), src.Timestamp(), src.Attributes(), dp)
+					}
+				case pmetric.MetricTypeSum:
+					dps := m.Sum().DataPoints()
+					for l := 0; l < dps.Len(); l++ {
+						src := dps.At(l)
+						dp := h.DataPoints().AppendEmpty()
+						p.convertDataPoint(src.DoubleValue(), src.Timestamp(), src.Attributes(), dp)
+					}
+				default:
+					continue
+				}
+
+				// remove original metric
+				metrics.RemoveIf(func(x pmetric.Metric) bool { return x.Name() == m.Name() })
+				// restart scanning since slice changed
+				k = -1
+			}
+		}
+	}
+
+	return p.GetNext().ConsumeMetrics(ctx, md)
+}
+
+func (p *processorImpl) convertDataPoint(val float64, ts pcommon.Timestamp, attrs pcommon.Map, dp pmetric.HistogramDataPoint) {
+	dp.SetTimestamp(ts)
+	attrs.CopyTo(dp.Attributes())
+	dp.SetCount(1)
+	dp.SetSum(val)
+	counts := make([]uint64, len(p.config.Boundaries)+1)
+	idx := p.bucketIndex(val)
+	counts[idx] = 1
+	dp.BucketCounts().FromRaw(counts)
+}
+
+func (p *processorImpl) shouldConvert(name string) bool {
+	for _, n := range p.config.MetricNames {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *processorImpl) bucketIndex(v float64) int {
+	for i, b := range p.config.Boundaries {
+		if v <= b {
+			return i
+		}
+	}
+	return len(p.config.Boundaries)
+}

--- a/internal/processor/timeseries_estimator/config.go
+++ b/internal/processor/timeseries_estimator/config.go
@@ -1,0 +1,13 @@
+package timeseries_estimator
+
+import "github.com/deepaucksharma/Phoenix/internal/processor/base"
+
+// Config defines configuration for the timeseries estimator processor.
+type Config struct {
+	*base.BaseConfig `mapstructure:",squash"`
+}
+
+// Validate validates the configuration.
+func (c *Config) Validate() error {
+	return c.BaseConfig.Validate()
+}

--- a/internal/processor/timeseries_estimator/factory.go
+++ b/internal/processor/timeseries_estimator/factory.go
@@ -1,0 +1,40 @@
+package timeseries_estimator
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/base"
+)
+
+const Type = "timeseries_estimator"
+
+// NewFactory creates a factory for the timeseries estimator processor.
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		Type,
+		createDefaultConfig,
+		processor.WithMetrics(createMetricsProcessor, component.StabilityLevelAlpha),
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{BaseConfig: base.NewBaseConfig()}
+}
+
+func createMetricsProcessor(
+	ctx context.Context,
+	set processor.CreateSettings,
+	cfg component.Config,
+	next consumer.Metrics,
+) (processor.Metrics, error) {
+	c, ok := cfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config type")
+	}
+	return newProcessor(c, set, next)
+}

--- a/internal/processor/timeseries_estimator/processor.go
+++ b/internal/processor/timeseries_estimator/processor.go
@@ -1,0 +1,80 @@
+package timeseries_estimator
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/base"
+)
+
+type processorImpl struct {
+	*base.BaseProcessor
+	config *Config
+}
+
+var _ processor.Metrics = (*processorImpl)(nil)
+
+func newProcessor(cfg *Config, set processor.CreateSettings, next consumer.Metrics) (*processorImpl, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &processorImpl{
+		BaseProcessor: base.NewBaseProcessor(set.TelemetrySettings.Logger, next, Type, set.ID),
+		config:        cfg,
+	}, nil
+}
+
+func (p *processorImpl) Start(ctx context.Context, host component.Host) error {
+	return p.BaseProcessor.Start(ctx, host)
+}
+
+func (p *processorImpl) Shutdown(ctx context.Context) error {
+	return p.BaseProcessor.Shutdown(ctx)
+}
+
+func (p *processorImpl) Capabilities() consumer.Capabilities {
+	return p.BaseProcessor.Capabilities()
+}
+
+func (p *processorImpl) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.config.Enabled {
+		return p.GetNext().ConsumeMetrics(ctx, md)
+	}
+
+	var count int64
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					count += int64(m.Gauge().DataPoints().Len())
+				case pmetric.MetricTypeSum:
+					count += int64(m.Sum().DataPoints().Len())
+				case pmetric.MetricTypeHistogram:
+					count += int64(m.Histogram().DataPoints().Len())
+				case pmetric.MetricTypeSummary:
+					count += int64(m.Summary().DataPoints().Len())
+				}
+			}
+		}
+	}
+
+	rm := md.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("phoenix.timeseries.estimate")
+	dp := metric.SetEmptyGauge().DataPoints().AppendEmpty()
+	dp.SetIntValue(count)
+
+	return p.GetNext().ConsumeMetrics(ctx, md)
+}

--- a/test/processors/cpu_histogram_converter/processor_test.go
+++ b/test/processors/cpu_histogram_converter/processor_test.go
@@ -1,0 +1,112 @@
+package cpu_histogram_converter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/base"
+	"github.com/deepaucksharma/Phoenix/internal/processor/cpu_histogram_converter"
+)
+
+func generateCPUMetrics(values []float64) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	m := sm.Metrics().AppendEmpty()
+	m.SetName("process.cpu.utilization")
+	gauge := m.SetEmptyGauge()
+	for _, v := range values {
+		dp := gauge.DataPoints().AppendEmpty()
+		dp.SetDoubleValue(v)
+		dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	}
+	return md
+}
+
+func TestCPUHistogramFactory(t *testing.T) {
+	factory := cpu_histogram_converter.NewFactory()
+	assert.NotNil(t, factory)
+	cfg := factory.CreateDefaultConfig()
+	assert.IsType(t, &cpu_histogram_converter.Config{}, cfg)
+}
+
+func TestCPUHistogramConverterPatterns(t *testing.T) {
+	factory := cpu_histogram_converter.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*cpu_histogram_converter.Config)
+
+	sink := new(consumertest.MetricsSink)
+	proc, err := factory.CreateMetrics(context.Background(), processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	}, cfg, sink)
+	require.NoError(t, err)
+
+	require.NoError(t, proc.Start(context.Background(), nil))
+
+	patterns := [][]float64{
+		{10, 10, 10},     // steady
+		{0, 100, 0, 100}, // spikes
+		{0, 0, 0},        // zero usage
+	}
+	for _, ptn := range patterns {
+		md := generateCPUMetrics(ptn)
+		err = proc.ConsumeMetrics(context.Background(), md)
+		require.NoError(t, err)
+	}
+
+	out := sink.AllMetrics()
+	require.NotEmpty(t, out)
+	processed := out[len(out)-1]
+	foundHistogram := false
+	for i := 0; i < processed.ResourceMetrics().Len(); i++ {
+		rm := processed.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				if m.Type() == pmetric.MetricTypeHistogram && m.Name() == "process.cpu.utilization" {
+					foundHistogram = true
+				}
+			}
+		}
+	}
+	assert.True(t, foundHistogram, "histogram metric not found")
+
+	assert.NoError(t, proc.Shutdown(context.Background()))
+}
+
+func TestCPUHistogramConverterEmptyInput(t *testing.T) {
+	factory := cpu_histogram_converter.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*cpu_histogram_converter.Config)
+
+	sink := new(consumertest.MetricsSink)
+	proc, err := factory.CreateMetrics(context.Background(), processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	}, cfg, sink)
+	require.NoError(t, err)
+	require.NoError(t, proc.Start(context.Background(), nil))
+
+	md := pmetric.NewMetrics()
+	err = proc.ConsumeMetrics(context.Background(), md)
+	require.NoError(t, err)
+	assert.NotEmpty(t, sink.AllMetrics())
+	assert.NoError(t, proc.Shutdown(context.Background()))
+}
+
+func TestCPUHistogramConverterInvalidConfig(t *testing.T) {
+	cfg := &cpu_histogram_converter.Config{
+		BaseConfig: base.NewBaseConfig(),
+		Boundaries: []float64{50, 10},
+	}
+	err := cfg.Validate()
+	assert.Error(t, err)
+}

--- a/test/processors/timeseries_estimator/processor_test.go
+++ b/test/processors/timeseries_estimator/processor_test.go
@@ -1,0 +1,84 @@
+package timeseries_estimator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/timeseries_estimator"
+	"github.com/deepaucksharma/Phoenix/test/testutils"
+)
+
+func TestTimeseriesEstimatorFactory(t *testing.T) {
+	factory := timeseries_estimator.NewFactory()
+	assert.NotNil(t, factory)
+	cfg := factory.CreateDefaultConfig()
+	assert.IsType(t, &timeseries_estimator.Config{}, cfg)
+}
+
+func TestTimeseriesEstimatorHighCardinality(t *testing.T) {
+	factory := timeseries_estimator.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*timeseries_estimator.Config)
+
+	sink := new(consumertest.MetricsSink)
+	proc, err := factory.CreateMetrics(context.Background(), processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	}, cfg, sink)
+	require.NoError(t, err)
+
+	err = proc.Start(context.Background(), nil)
+	require.NoError(t, err)
+
+	md := testutils.GenerateHighCardinalityMetrics(50)
+	err = proc.ConsumeMetrics(context.Background(), md)
+	require.NoError(t, err)
+
+	out := sink.AllMetrics()
+	require.NotEmpty(t, out)
+
+	found := false
+	metrics := out[0]
+	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
+		rm := metrics.ResourceMetrics().At(i)
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				if sm.Metrics().At(k).Name() == "phoenix.timeseries.estimate" {
+					found = true
+				}
+			}
+		}
+	}
+	assert.True(t, found, "expected estimate metric")
+
+	assert.NoError(t, proc.Shutdown(context.Background()))
+}
+
+func TestTimeseriesEstimatorEmptyInput(t *testing.T) {
+	factory := timeseries_estimator.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*timeseries_estimator.Config)
+
+	sink := new(consumertest.MetricsSink)
+	proc, err := factory.CreateMetrics(context.Background(), processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	}, cfg, sink)
+	require.NoError(t, err)
+
+	err = proc.Start(context.Background(), nil)
+	require.NoError(t, err)
+
+	md := pmetric.NewMetrics()
+	err = proc.ConsumeMetrics(context.Background(), md)
+	require.NoError(t, err)
+
+	out := sink.AllMetrics()
+	require.NotEmpty(t, out)
+	assert.NoError(t, proc.Shutdown(context.Background()))
+}


### PR DESCRIPTION
## Summary
- add new `timeseries_estimator` processor
- add new `cpu_histogram_converter` processor
- create tests for new processors covering factory registration, high-cardinality inputs, CPU patterns and edge cases

## Testing
- `npm test` *(fails: directory prefix . does not contain main module)*
- `go test ./...` *(fails: directory prefix . does not contain main module)*