### PR TITLE
Update docs for new metric pipeline

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,10 +16,7 @@ Phoenix implements a dual-pipeline architecture that separates data processing f
 
 1. **Data Pipeline**:
    - Collects metrics from standard OpenTelemetry receivers (e.g., hostmetrics)
-   - Processes through various adaptive processors:
-     - `priority_tagger`: Tags resources with priority levels
-     - `adaptive_topk`: Dynamically filters to the most important resources
-     - `others_rollup`: Aggregates lower-priority resources
+   - Processes metrics through the unified `metric_pipeline` processor for resource filtering and transformation
    - Exports processed metrics to configured destinations
    - Each processor emits self-metrics about its own operation
 

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -16,10 +16,8 @@ Processors handle metrics data transformation and filtering:
 
 | Processor | Description | Status |
 |-----------|-------------|--------|
-| [priority_tagger](./processors/priority_tagger.md) | Tags resources with priority levels based on rules | Implemented |
-| [adaptive_topk](./processors/adaptive_topk.md) | Dynamically adjusts k parameter based on coverage score | Implemented |
+| [metric_pipeline](./processor/metric_pipeline.md) | Unified filtering and transformation processor | Implemented |
 | [adaptive_pid](./processors/adaptive_pid.md) | Generates configuration patches using PID control | Implemented |
-| [others_rollup](./processors/others_rollup.md) | Aggregates non-priority processes | Implemented |
 | [cardinality_guardian](./processors/cardinality_guardian.md) | Controls metrics cardinality | In Progress |
 | [reservoir_sampler](./processors/reservoir_sampler.md) | Statistical sampling with adjustable reservoir sizes | In Progress |
 | [process_context_learner](./processors/process_context_learner.md) | Learns and associates context with processes | In Progress |
@@ -42,7 +40,9 @@ Connectors bridge between components:
 
 | Connector | Description | Status |
 |-----------|-------------|--------|
-| [pic_connector](./connectors/pic_connector.md) | Connects adaptive_pid to pic_control_ext | Implemented |
+| None currently in production | - | - |
+
+*Note: The previously documented `pic_connector` has been removed as part of the codebase cleanup.*
 
 ### Control Components
 
@@ -80,13 +80,8 @@ Phoenix implements a dual pipeline architecture that separates data processing f
         │                          │
         ▼                          ▼
 ┌───────────────┐          ┌───────────────┐
-│  Exporters    │          │ pic_connector │
-└───────────────┘          └───────┬───────┘
-                                   │
-                                   ▼
-                           ┌───────────────┐
-                           │ pic_control   │
-                           │   extension   │
+│  Exporters    │          │ pic_control   │
+└───────────────┘          │   extension   │
                            └───────┬───────┘
                                    │
                                    ▼

--- a/docs/components/extensions/README.md
+++ b/docs/components/extensions/README.md
@@ -6,9 +6,7 @@ This directory contains documentation for the extensions implemented in SA-OMF.
 
 | Extension | Description | Status |
 |-----------|-------------|--------|
-| None currently in production | - | - |
-
-*Note: The previously documented `pic_control_ext` has been removed as part of the codebase cleanup.*
+| pic_control_ext | Central governance layer for configuration changes | Implemented |
 
 ## Extension Concepts
 

--- a/docs/components/processors/README.md
+++ b/docs/components/processors/README.md
@@ -6,9 +6,7 @@ This directory contains documentation for the various processors implemented in 
 
 | Processor | Description | Status |
 |-----------|-------------|--------|
-| [priority_tagger](./priority_tagger.md) | Tags metrics with priority levels based on rules | Stable |
-| [adaptive_topk](./adaptive_topk.md) | Dynamically adjusts k value for top-k filtering | Stable |
-| [others_rollup](./others_rollup.md) | Aggregates low-priority metrics to reduce cardinality | Stable |
+| [metric_pipeline](../processor/metric_pipeline.md) | Unified filtering and transformation processor | Stable |
 | [adaptive_pid](./adaptive_pid.md) | PID-based processor for monitoring KPIs and adapting behavior | Stable |
 | [cardinality_guardian](./cardinality_guardian.md) | Controls metrics cardinality based on resource usage | Planning |
 | [reservoir_sampler](./reservoir_sampler.md) | Provides statistical sampling with adjustable rates | Implemented |

--- a/docs/components/processors/adaptive_pid.md
+++ b/docs/components/processors/adaptive_pid.md
@@ -25,7 +25,7 @@ adaptive_pid:
   controllers:
     - name: coverage_controller
       enabled: true
-      kpi_metric_name: aemf_impact_adaptive_topk_resource_coverage_percent_avg_1m
+      kpi_metric_name: phoenix.filter.coverage_ratio_avg_1m
       kpi_target_value: 0.90
       kp: 30
       ki: 5
@@ -117,7 +117,7 @@ adaptive_pid_config:
   controllers:
     - name: coverage_controller
       enabled: true
-      kpi_metric_name: aemf_impact_adaptive_topk_resource_coverage_percent_avg_1m
+      kpi_metric_name: phoenix.filter.coverage_ratio_avg_1m
       kpi_target_value: 0.90
       kp: 30
       ki: 5
@@ -128,6 +128,6 @@ service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [priority_tagger, adaptive_topk, adaptive_pid]
+      processors: [metric_pipeline, adaptive_pid]
       exporters: [prometheusremotewrite]
 ```

--- a/docs/integrations/new-relic-otlp-export.md
+++ b/docs/integrations/new-relic-otlp-export.md
@@ -31,7 +31,7 @@ Use the prebuilt configuration in `configs/default/config.yaml` which includes:
 - Process-only metrics collection
 - Attribute filtering to control cardinality
 - Histogram optimization for New Relic visualization
-- Adaptive k-value control for top processes
+- Adaptive resource filtering through the `metric_pipeline` processor
 
 ### 3. Start the Collector
 
@@ -61,13 +61,12 @@ receivers:
 
 ### Adaptive Processing Pipeline
 
-The metrics pipeline uses these processors in sequence:
+The metrics pipeline uses the unified **metric_pipeline** processor which combines:
 
-1. **priority_tagger**: Tags processes by importance (critical, high, medium, low)
-2. **adaptive_topk**: Dynamically adjusts which processes pass through based on CPU usage
-3. **others_rollup**: Aggregates low-priority processes into a single "others" metric
-4. **histogram_aggregator**: Optimizes histograms for New Relic visualization
-5. **attributes/process**: Filters and normalizes attributes to control cardinality
+1. Priority tagging and top-K filtering with adaptive parameters
+2. Rollup aggregation for low-priority processes
+3. Histogram optimization for New Relic visualization
+4. Attribute processing to control cardinality
 
 ### PID Controllers
 
@@ -95,7 +94,7 @@ Monitor the configuration through:
 
 ### Key Metrics to Watch
 
-- `aemf_impact_adaptive_topk_resource_coverage_percent`: Should stay near 95%
+- `phoenix.filter.coverage_ratio`: Should stay near 95%
 - `aemf_metrics_cardinality`: Total unique metrics being exported
 - `aemf_metrics_export_rate`: Rate of metrics being exported to New Relic
 
@@ -104,15 +103,15 @@ Monitor the configuration through:
 ### Common Issues
 
 1. **High Cardinality Alerts**: If New Relic shows high cardinality alerts:
-   - Decrease `k_max` in the adaptive_topk configuration
-   - Increase priority threshold for `others_rollup`
+   - Decrease `topk.k_max` in the `metric_pipeline` configuration
+   - Increase `rollup.priority_threshold` in the same configuration
 
 2. **Missing Important Processes**: If key processes aren't visible:
-   - Add them to the priority_tagger rules with "critical" priority
-   - Increase `k_min` value in adaptive_topk
+   - Add them to the `priority_rules` with "critical" priority
+   - Increase `topk.k_min` value in `metric_pipeline`
 
 3. **Poor Histogram Visualization**: If histograms don't display well:
-   - Adjust the `custom_boundaries` in histogram_aggregator processor
+   - Adjust `transformation.histograms.custom_boundaries` in `metric_pipeline`
 
 4. **Authentication Failures**:
    - Verify your NEW_RELIC_API_KEY environment variable is set correctly


### PR DESCRIPTION
## Summary
- document new `metric_pipeline` processor in component overview
- clarify that `pic_control_ext` extension remains and `pic_connector` is removed
- update architecture overview for consolidated pipeline
- revise adaptive PID docs and New Relic integration guide

## Testing
- `make test` *(fails: directory prefix does not contain main module)*