### PR TITLE
Implement timeseries estimator with HLL fallback

### DIFF
--- a/configs/process_metrics/config.yaml
+++ b/configs/process_metrics/config.yaml
@@ -100,6 +100,12 @@ processors:
         priority_threshold: low
         strategy: sum
         name_prefix: "phoenix.others.process"  # Use a prefix making clear these are aggregated
+
+  # Estimate active time series with circuit breaker
+  timeseries_estimator:
+    enabled: true
+    estimator_type: "exact"
+    max_unique_time_series: 5000
     
     # Metric transformation configuration tailored for New Relic
     transformation:
@@ -192,7 +198,7 @@ service:
     metrics/process:
       receivers: [hostmetrics]
       # Process flow: Convert CPU counters to delta → Process with unified metric pipeline → Batch for efficiency
-      processors: [cumulativetodelta, metric_pipeline, batch]
+      processors: [cumulativetodelta, metric_pipeline, timeseries_estimator, batch]
       exporters: [logging, otlphttp/newrelic]
     
     # Self-metrics pipeline to export Phoenix's own metrics to New Relic

--- a/configs/process_metrics/policy.yaml
+++ b/configs/process_metrics/policy.yaml
@@ -80,8 +80,13 @@ processors_config:
             action: "insert"
             value: "phoenix-process-metrics"
           - key: "instrumentation.provider"
-            action: "insert" 
-            value: "phoenix"
+          action: "insert"
+          value: "phoenix"
+
+  timeseries_estimator:
+    enabled: true
+    estimator_type: "exact"
+    max_unique_time_series: 5000
 
 # Adaptive PID controller configuration for process metrics monitoring
 adaptive_pid_config:

--- a/docs/components/processors/README.md
+++ b/docs/components/processors/README.md
@@ -12,6 +12,7 @@ This directory contains documentation for the various processors implemented in 
 | [adaptive_pid](./adaptive_pid.md) | PID-based processor for monitoring KPIs and adapting behavior | Stable |
 | [cardinality_guardian](./cardinality_guardian.md) | Controls metrics cardinality based on resource usage | Planning |
 | [reservoir_sampler](./reservoir_sampler.md) | Provides statistical sampling with adjustable rates | Implemented |
+| [timeseries_estimator](./timeseries_estimator.md) | Estimates active time series with circuit breaker | Implemented |
 
 ## Processor Concepts
 

--- a/docs/components/processors/timeseries_estimator.md
+++ b/docs/components/processors/timeseries_estimator.md
@@ -1,0 +1,28 @@
+# Timeseries Estimator Processor
+
+The `timeseries_estimator` processor tracks the number of unique time series
+seen in the metrics pipeline.  It begins in **exact** mode where every
+series key is stored in memory.  When the count of unique series reaches the
+configured `max_unique_time_series` limit the processor automatically switches to
+a probabilistic estimator based on HyperLogLog.  This provides a circuit breaker
+to prevent excessive memory usage while still producing an estimate of the
+active series count.
+
+## Configuration
+
+```yaml
+processors:
+  timeseries_estimator:
+    enabled: true
+    estimator_type: "exact"
+    max_unique_time_series: 5000
+```
+
+- `estimator_type` – starting estimator. `"exact"` stores every series and is
+  accurate until the limit is reached. `"hll"` starts directly in probabilistic
+  mode.
+- `max_unique_time_series` – maximum number of series tracked exactly before
+  falling back to HyperLogLog.
+
+The processor exposes a self‑metric `phoenix.timeseries_estimator.memory_bytes`
+which records the current memory usage of the estimator.

--- a/internal/processor/timeseries_estimator/config.go
+++ b/internal/processor/timeseries_estimator/config.go
@@ -1,0 +1,46 @@
+package timeseries_estimator
+
+import (
+	"fmt"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/base"
+)
+
+// Config defines configuration for the timeseries estimator processor.
+type Config struct {
+	*base.BaseConfig `mapstructure:",squash"`
+
+	// EstimatorType selects the estimation algorithm. "exact" tracks every
+	// unique series until MaxUniqueTimeSeries is reached before switching
+	// to a probabilistic estimator.
+	EstimatorType string `mapstructure:"estimator_type"`
+
+	// MaxUniqueTimeSeries sets the maximum number of unique time series to
+	// track when EstimatorType is "exact" before falling back to a
+	// probabilistic approach.
+	MaxUniqueTimeSeries int `mapstructure:"max_unique_time_series"`
+}
+
+// Validate checks if the configuration is valid.
+func (cfg *Config) Validate() error {
+	if err := cfg.BaseConfig.Validate(); err != nil {
+		return err
+	}
+
+	if cfg.MaxUniqueTimeSeries <= 0 {
+		return fmt.Errorf("max_unique_time_series must be positive")
+	}
+
+	if cfg.EstimatorType == "" {
+		cfg.EstimatorType = "exact"
+	}
+
+	switch cfg.EstimatorType {
+	case "exact", "hll":
+		// valid types
+	default:
+		return fmt.Errorf("invalid estimator_type: %s", cfg.EstimatorType)
+	}
+
+	return nil
+}

--- a/internal/processor/timeseries_estimator/factory.go
+++ b/internal/processor/timeseries_estimator/factory.go
@@ -1,0 +1,42 @@
+package timeseries_estimator
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/deepaucksharma/Phoenix/internal/processor/base"
+)
+
+const (
+	// Type is the configuration type key for this processor.
+	Type = "timeseries_estimator"
+)
+
+// NewFactory returns a new processor factory.
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		Type,
+		createDefaultConfig,
+		processor.WithMetrics(createProcessor, component.StabilityLevelAlpha),
+	)
+}
+
+func createDefaultConfig() component.Config {
+	return &Config{
+		BaseConfig:          base.NewBaseConfig(),
+		EstimatorType:       "exact",
+		MaxUniqueTimeSeries: 5000,
+	}
+}
+
+func createProcessor(ctx context.Context, settings processor.Settings, cfg component.Config, next consumer.Metrics) (processor.Metrics, error) {
+	pcfg, ok := cfg.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("invalid config type for %s", Type)
+	}
+	return newProcessor(pcfg, settings, next)
+}

--- a/internal/processor/timeseries_estimator/processor.go
+++ b/internal/processor/timeseries_estimator/processor.go
@@ -1,0 +1,171 @@
+package timeseries_estimator
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+	"github.com/deepaucksharma/Phoenix/internal/processor/base"
+	"github.com/deepaucksharma/Phoenix/pkg/util/hll"
+)
+
+type processorImpl struct {
+	*base.UpdateableProcessor
+	config *Config
+
+	uniqueTimeSeries map[string]struct{}
+	hllEstimator     *hll.HyperLogLog
+	exact            bool
+
+	memoryGauge interface{}
+}
+
+var _ processor.Metrics = (*processorImpl)(nil)
+var _ interfaces.UpdateableProcessor = (*processorImpl)(nil)
+
+func newProcessor(cfg *Config, settings processor.Settings, next consumer.Metrics) (*processorImpl, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	up := base.NewUpdateableProcessor(settings.TelemetrySettings.Logger, next, Type, settings.ID, cfg)
+
+	p := &processorImpl{
+		UpdateableProcessor: up,
+		config:              cfg,
+		exact:               strings.ToLower(cfg.EstimatorType) != "hll",
+	}
+
+	if p.exact {
+		p.uniqueTimeSeries = make(map[string]struct{})
+	} else {
+		p.hllEstimator = hll.NewDefault()
+	}
+
+	return p, nil
+}
+
+func (p *processorImpl) Start(ctx context.Context, host component.Host) error {
+	if err := p.UpdateableProcessor.Start(ctx, host); err != nil {
+		return err
+	}
+	if emitter := p.GetMetricsEmitter(); emitter != nil {
+		p.memoryGauge, _ = emitter.RegisterGauge("phoenix.timeseries_estimator.memory_bytes", "Memory used by the time series estimator")
+	}
+	return nil
+}
+
+func (p *processorImpl) record(key string) {
+	if p.exact {
+		if p.uniqueTimeSeries == nil {
+			p.uniqueTimeSeries = make(map[string]struct{})
+		}
+		p.uniqueTimeSeries[key] = struct{}{}
+		if len(p.uniqueTimeSeries) >= p.config.MaxUniqueTimeSeries {
+			p.hllEstimator = hll.NewDefault()
+			for k := range p.uniqueTimeSeries {
+				p.hllEstimator.AddString(k)
+			}
+			p.uniqueTimeSeries = nil
+			p.exact = false
+			p.config.EstimatorType = "hll"
+			p.GetLogger().Warn("max unique time series reached, switching to probabilistic estimator")
+		}
+	} else {
+		if p.hllEstimator == nil {
+			p.hllEstimator = hll.NewDefault()
+		}
+		p.hllEstimator.AddString(key)
+	}
+}
+
+func buildKey(name string, resAttrs, attrs pcommon.Map) string {
+	parts := []string{name}
+
+	if resAttrs.Len() > 0 {
+		keys := make([]string, 0, resAttrs.Len())
+		resAttrs.Range(func(k string, _ pcommon.Value) bool {
+			keys = append(keys, k)
+			return true
+		})
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := resAttrs.Get(k)
+			parts = append(parts, fmt.Sprintf("%s=%v", k, v.AsString()))
+		}
+	}
+
+	if attrs.Len() > 0 {
+		keys := make([]string, 0, attrs.Len())
+		attrs.Range(func(k string, _ pcommon.Value) bool {
+			keys = append(keys, k)
+			return true
+		})
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := attrs.Get(k)
+			parts = append(parts, fmt.Sprintf("%s=%v", k, v.AsString()))
+		}
+	}
+
+	return strings.Join(parts, "|")
+}
+
+func (p *processorImpl) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	p.Lock()
+	defer p.Unlock()
+
+	if !p.config.Enabled {
+		return p.GetNext().ConsumeMetrics(ctx, md)
+	}
+
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		res := rm.Resource().Attributes()
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					g := m.Gauge()
+					for x := 0; x < g.DataPoints().Len(); x++ {
+						dp := g.DataPoints().At(x)
+						p.record(buildKey(m.Name(), res, dp.Attributes()))
+					}
+				case pmetric.MetricTypeSum:
+					s := m.Sum()
+					for x := 0; x < s.DataPoints().Len(); x++ {
+						dp := s.DataPoints().At(x)
+						p.record(buildKey(m.Name(), res, dp.Attributes()))
+					}
+				case pmetric.MetricTypeHistogram:
+					h := m.Histogram()
+					for x := 0; x < h.DataPoints().Len(); x++ {
+						dp := h.DataPoints().At(x)
+						p.record(buildKey(m.Name(), res, dp.Attributes()))
+					}
+				}
+			}
+		}
+	}
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	if emitter := p.GetMetricsEmitter(); emitter != nil {
+		emitter.AddMetrics(map[string]any{
+			"phoenix.timeseries_estimator.memory_bytes": float64(ms.Alloc),
+		})
+	}
+
+	return p.GetNext().ConsumeMetrics(ctx, md)
+}

--- a/pkg/policy/schema.go
+++ b/pkg/policy/schema.go
@@ -37,7 +37,7 @@ const Schema = `{
     },
     "processors_config": {
       "type": "object",
-      "required": ["priority_tagger", "adaptive_topk", "cardinality_guardian", "reservoir_sampler", "others_rollup"],
+      "required": ["priority_tagger", "adaptive_topk", "cardinality_guardian", "reservoir_sampler", "others_rollup", "timeseries_estimator"],
       "properties": {
         "priority_tagger": {
           "type": "object",
@@ -88,6 +88,15 @@ const Schema = `{
           "required": ["enabled"],
           "properties": {
             "enabled": { "type": "boolean" }
+          }
+        },
+        "timeseries_estimator": {
+          "type": "object",
+          "required": ["enabled", "max_unique_time_series"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "estimator_type": { "type": "string" },
+            "max_unique_time_series": { "type": "integer", "minimum": 100 }
           }
         }
       }

--- a/test/processors/timeseries_estimator/processor_test.go
+++ b/test/processors/timeseries_estimator/processor_test.go
@@ -1,0 +1,56 @@
+package timeseriesestimator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+	"go.uber.org/zap"
+
+	"github.com/deepaucksharma/Phoenix/internal/interfaces"
+	tse "github.com/deepaucksharma/Phoenix/internal/processor/timeseries_estimator"
+)
+
+// Test that the processor switches from exact to HLL when the limit is exceeded.
+func TestTimeseriesEstimatorSwitch(t *testing.T) {
+	factory := tse.NewFactory()
+	cfg := factory.CreateDefaultConfig().(*tse.Config)
+	cfg.MaxUniqueTimeSeries = 2
+	cfg.EstimatorType = "exact"
+
+	next := new(consumertest.MetricsSink)
+	proc, err := factory.CreateMetrics(context.Background(), processor.Settings{
+		TelemetrySettings: component.TelemetrySettings{Logger: zap.NewNop()},
+	}, cfg, next)
+	require.NoError(t, err)
+
+	err = proc.Start(context.Background(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = proc.Shutdown(context.Background()) })
+
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+
+	for i := 0; i < 3; i++ {
+		m := sm.Metrics().AppendEmpty()
+		m.SetName(fmt.Sprintf("metric%d", i))
+		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
+		dp.SetDoubleValue(float64(i))
+	}
+
+	err = proc.ConsumeMetrics(context.Background(), md)
+	require.NoError(t, err)
+
+	up := proc.(interfaces.UpdateableProcessor)
+	status, err := up.GetConfigStatus(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "hll", status.Parameters["estimator_type"])
+}


### PR DESCRIPTION
## Summary
- add `timeseries_estimator` processor with exact/HLL modes
- expose memory usage self‑metric and circuit breaker
- update process metrics configs and policies
- extend policy schema for `timeseries_estimator`
- document the new processor and config
- add unit test

## Testing
- `go test ./...` *(fails: directory prefix does not contain main module)*