### PR TITLE
Refactor policy configs to use metric pipeline

### DIFF
--- a/configs/development/policy.yaml
+++ b/configs/development/policy.yaml
@@ -4,35 +4,34 @@ global_settings:
   collector_rss_safety_limit_mib: 350
 
 processors_config:
-  # Priority tagging configuration
-  priority_tagger:
-    enabled: true
-    rules:
-      - match: "process.command_line=~/.*java.*/"
-        priority: high
-      - match: "process.name=~/nginx|httpd/"
-        priority: high
-      - match: "process.name=~/mysql|postgres|mongodb/"
-        priority: critical
-      - match: "process.command_line=~/.*python.*/"
-        priority: medium
-      - match: ".*"
-        priority: low
-  
-  # Adaptive top-k processor configuration
-  adaptive_topk:
-    enabled: true
-    k_value: 30
-    k_min: 10
-    k_max: 60
-    resource_field: "process.executable.name"
-    counter_field: "process.cpu.utilization"
-  
-  # Others rollup processor for low-priority processes
-  others_rollup:
-    enabled: true
-    priority_threshold: "low"
-    metric_name_prefix: "others"
+  metric_pipeline:
+    resource_filter:
+      enabled: true
+      filter_strategy: hybrid
+      priority_attribute: "aemf.process.priority"
+      priority_rules:
+        - match: "process.command_line=~/.*java.*/"
+          priority: high
+        - match: "process.name=~/nginx|httpd/"
+          priority: high
+        - match: "process.name=~/mysql|postgres|mongodb/"
+          priority: critical
+        - match: "process.command_line=~/.*python.*/"
+          priority: medium
+        - match: ".*"
+          priority: low
+      topk:
+        k_value: 25
+        k_min: 10
+        k_max: 50
+        resource_field: "process.executable.name"
+        counter_field: "process.cpu.utilization"
+        coverage_target: 0.95
+      rollup:
+        enabled: true
+        priority_threshold: "low"
+        strategy: "sum"
+        name_prefix: "others"
 
 # Adaptive PID controller configuration
 adaptive_pid_config:
@@ -47,8 +46,8 @@ adaptive_pid_config:
       hysteresis_percent: 3
       integral_windup_limit: 100
       output_config_patches:
-        - target_processor_name: adaptive_topk
-          parameter_path: k_value
+        - target_processor_name: metric_pipeline
+          parameter_path: resource_filter.topk.k_value
           change_scale_factor: -20.0
           min_value: 10
           max_value: 60
@@ -64,8 +63,8 @@ adaptive_pid_config:
       hysteresis_percent: 5
       integral_windup_limit: 50
       output_config_patches:
-        - target_processor_name: others_rollup
-          parameter_path: priority_threshold
+        - target_processor_name: metric_pipeline
+          parameter_path: resource_filter.rollup.priority_threshold
           change_scale_factor: 1.0
           min_value: 0.0  # Corresponds to "low"
           max_value: 3.0  # Corresponds to "critical"
@@ -73,8 +72,10 @@ adaptive_pid_config:
 # Safety mode configurations
 safety_config:
   safe_mode_processor_configs:
-    adaptive_topk:
-      k_value: 10
-    others_rollup:
-      priority_threshold: "critical"
+    metric_pipeline:
+      resource_filter:
+        topk:
+          k_value: 10
+        rollup:
+          priority_threshold: "critical"
 

--- a/configs/examples/policy.yaml
+++ b/configs/examples/policy.yaml
@@ -4,26 +4,35 @@ global_settings:
   collector_rss_safety_limit_mib: 350
 
 processors_config:
-  priority_tagger:
-    enabled: true
-    rules:
-      - match: "process.command_line=~/.*java.*/"
-        priority: high
-      - match: "process.name=~/nginx|httpd/"
-        priority: high
-      - match: "process.name=~/mysql|postgres|mongodb/"
-        priority: critical
-      - match: "process.command_line=~/.*python.*/"
-        priority: medium
-      - match: ".*"
-        priority: low
-  
-  adaptive_topk:
-    enabled: true
-    k_value: 30
-    k_min: 10
-    k_max: 60
-  
+  metric_pipeline:
+    resource_filter:
+      enabled: true
+      filter_strategy: hybrid
+      priority_attribute: "aemf.process.priority"
+      priority_rules:
+        - match: "process.command_line=~/.*java.*/"
+          priority: high
+        - match: "process.name=~/nginx|httpd/"
+          priority: high
+        - match: "process.name=~/mysql|postgres|mongodb/"
+          priority: critical
+        - match: "process.command_line=~/.*python.*/"
+          priority: medium
+        - match: ".*"
+          priority: low
+      topk:
+        k_value: 25
+        k_min: 10
+        k_max: 50
+        resource_field: "process.executable.name"
+        counter_field: "process.cpu.utilization"
+        coverage_target: 0.95
+      rollup:
+        enabled: false
+        strategy: "sum"
+        priority_threshold: "low"
+        name_prefix: "others"
+
   cardinality_guardian:
     enabled: false
     max_unique: 1000
@@ -32,9 +41,6 @@ processors_config:
     enabled: false
     reservoir_size: 100
   
-  others_rollup:
-    enabled: false
-
 pid_decider_config:
   controllers:
     - name: coverage_controller
@@ -46,8 +52,8 @@ pid_decider_config:
       kd: 0
       hysteresis_percent: 3
       output_config_patches:
-        - target_processor_name: adaptive_topk
-          parameter_path: k_value
+        - target_processor_name: metric_pipeline
+          parameter_path: resource_filter.topk.k_value
           change_scale_factor: -20.0
           min_value: 10
           max_value: 60
@@ -57,8 +63,10 @@ pic_control_config:
   max_patches_per_minute: 3
   patch_cooldown_seconds: 10
   safe_mode_processor_configs:
-    adaptive_topk:
-      k_value: 10
+    metric_pipeline:
+      resource_filter:
+        topk:
+          k_value: 10
     cardinality_guardian:
       max_unique: 100
 
@@ -67,7 +75,7 @@ service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [priority_tagger, adaptive_topk]
+      processors: [metric_pipeline]
       exporters: [prometheusremotewrite]
     control:
       receivers: [prometheus/self]

--- a/configs/production/policy.yaml
+++ b/configs/production/policy.yaml
@@ -4,35 +4,34 @@ global_settings:
   collector_rss_safety_limit_mib: 350
 
 processors_config:
-  # Priority tagging configuration
-  priority_tagger:
-    enabled: true
-    rules:
-      - match: "process.command_line=~/.*java.*/"
-        priority: high
-      - match: "process.name=~/nginx|httpd/"
-        priority: high
-      - match: "process.name=~/mysql|postgres|mongodb/"
-        priority: critical
-      - match: "process.command_line=~/.*python.*/"
-        priority: medium
-      - match: ".*"
-        priority: low
-  
-  # Adaptive top-k processor configuration
-  adaptive_topk:
-    enabled: true
-    k_value: 30
-    k_min: 10
-    k_max: 60
-    resource_field: "process.executable.name"
-    counter_field: "process.cpu.utilization"
-  
-  # Others rollup processor for low-priority processes
-  others_rollup:
-    enabled: true
-    priority_threshold: "low"
-    metric_name_prefix: "others"
+  metric_pipeline:
+    resource_filter:
+      enabled: true
+      filter_strategy: hybrid
+      priority_attribute: "aemf.process.priority"
+      priority_rules:
+        - match: "process.command_line=~/.*java.*/"
+          priority: high
+        - match: "process.name=~/nginx|httpd/"
+          priority: high
+        - match: "process.name=~/mysql|postgres|mongodb/"
+          priority: critical
+        - match: "process.command_line=~/.*python.*/"
+          priority: medium
+        - match: ".*"
+          priority: low
+      topk:
+        k_value: 25
+        k_min: 10
+        k_max: 50
+        resource_field: "process.executable.name"
+        counter_field: "process.cpu.utilization"
+        coverage_target: 0.95
+      rollup:
+        enabled: true
+        priority_threshold: "low"
+        strategy: "sum"
+        name_prefix: "others"
 
 # Adaptive PID controller configuration
 adaptive_pid_config:
@@ -47,8 +46,8 @@ adaptive_pid_config:
       hysteresis_percent: 3
       integral_windup_limit: 100
       output_config_patches:
-        - target_processor_name: adaptive_topk
-          parameter_path: k_value
+        - target_processor_name: metric_pipeline
+          parameter_path: resource_filter.topk.k_value
           change_scale_factor: -20.0
           min_value: 10
           max_value: 60
@@ -56,8 +55,10 @@ adaptive_pid_config:
 # Safety mode configurations
 safety_config:
   safe_mode_processor_configs:
-    adaptive_topk:
-      k_value: 10
-    others_rollup:
-      priority_threshold: "critical"
+    metric_pipeline:
+      resource_filter:
+        topk:
+          k_value: 10
+        rollup:
+          priority_threshold: "critical"
 

--- a/configs/testing/policy.yaml
+++ b/configs/testing/policy.yaml
@@ -4,35 +4,34 @@ global_settings:
   collector_rss_safety_limit_mib: 350
 
 processors_config:
-  # Priority tagging configuration
-  priority_tagger:
-    enabled: true
-    rules:
-      - match: "process.command_line=~/.*java.*/"
-        priority: high
-      - match: "process.name=~/nginx|httpd/"
-        priority: high
-      - match: "process.name=~/mysql|postgres|mongodb/"
-        priority: critical
-      - match: "process.command_line=~/.*python.*/"
-        priority: medium
-      - match: ".*"
-        priority: low
-  
-  # Adaptive top-k processor configuration 
-  adaptive_topk:
-    enabled: true
-    k_value: 30
-    k_min: 10
-    k_max: 60
-    resource_field: "process.executable.name"
-    counter_field: "process.cpu.utilization"
-  
-  # Others rollup processor for low-priority processes
-  others_rollup:
-    enabled: true
-    priority_threshold: "low"
-    metric_name_prefix: "others"
+  metric_pipeline:
+    resource_filter:
+      enabled: true
+      filter_strategy: hybrid
+      priority_attribute: "aemf.process.priority"
+      priority_rules:
+        - match: "process.command_line=~/.*java.*/"
+          priority: high
+        - match: "process.name=~/nginx|httpd/"
+          priority: high
+        - match: "process.name=~/mysql|postgres|mongodb/"
+          priority: critical
+        - match: "process.command_line=~/.*python.*/"
+          priority: medium
+        - match: ".*"
+          priority: low
+      topk:
+        k_value: 25
+        k_min: 10
+        k_max: 50
+        resource_field: "process.executable.name"
+        counter_field: "process.cpu.utilization"
+        coverage_target: 0.95
+      rollup:
+        enabled: true
+        priority_threshold: "low"
+        strategy: "sum"
+        name_prefix: "others"
 
 # Adaptive PID controller configuration
 adaptive_pid_config:
@@ -49,8 +48,8 @@ adaptive_pid_config:
       stall_threshold: 5  # Number of consecutive updates with no improvement
       use_bayesian: true  # Enable Bayesian optimization fallback for testing
       output_config_patches:
-        - target_processor_name: adaptive_topk
-          parameter_path: k_value
+        - target_processor_name: metric_pipeline
+          parameter_path: resource_filter.topk.k_value
           change_scale_factor: -20.0
           min_value: 10
           max_value: 60
@@ -58,8 +57,10 @@ adaptive_pid_config:
 # Safety mode configurations
 safety_config:
   safe_mode_processor_configs:
-    adaptive_topk:
-      k_value: 10
-    others_rollup:
-      priority_threshold: "critical"
+    metric_pipeline:
+      resource_filter:
+        topk:
+          k_value: 10
+        rollup:
+          priority_threshold: "critical"
 


### PR DESCRIPTION
## Summary
- replace legacy priority_tagger/adaptive_topk/others_rollup sections with `metric_pipeline.resource_filter`
- set default topk values following process metrics blueprint
- update PID controllers and safe-mode configs to patch the new processor hierarchy
- adjust example service pipeline

## Testing
- `make test-unit` *(fails: cannot find module providing package github.com/stretchr/testify/assert)*