### PR TITLE
Update docs for new metric pipeline

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -12,78 +12,62 @@ This directory contains architectural documentation for the Phoenix project (Sel
 
 ## Current Architecture Overview
 
-Phoenix implements a dual-pipeline architecture that separates data processing from control logic:
+Phoenix separates metric collection from control logic using two pipelines:
 
-1. **Data Pipeline**:
-   - Collects metrics from standard OpenTelemetry receivers (e.g., hostmetrics)
-   - Processes metrics through the unified `metric_pipeline` processor for resource filtering and transformation
+1. **Data Pipeline**
+   - Collects metrics from OpenTelemetry receivers (for example `hostmetrics`)
+   - Processes data through a single `metric_pipeline` processor for resource filtering and metric transformation
    - Exports processed metrics to configured destinations
-   - Each processor emits self-metrics about its own operation
+   - Every processor emits self-metrics about its own operation
 
-2. **Control Pipeline**:
-   - Monitors self-metrics from the data pipeline
-   - Runs PID controllers to calculate needed adjustments
-   - Generates configuration patches for the data pipeline
-   - Uses the `adaptive_pid` processor as its core component
-   - Connects to `pic_control_ext` to apply changes
-
-3. **Integration Components**:
-   - `pic_control_ext`: Central governance layer for configuration changes
-   - `UpdateableProcessor` interface: Allows processors to receive dynamic configuration
+2. **Control Pipeline**
+   - Consumes self-metrics from the data pipeline
+   - Uses the `adaptive_pid` processor to compute configuration patches
+   - Applies patches directly to the `metric_pipeline` processor via the `UpdateableProcessor` interface
 
 ## Architectural Principles
 
-1. **Separation of Concerns**: Clean separation between data processing and control logic
-2. **Self-Adaptation**: System automatically adjusts to changing conditions
-3. **Feedback Control**: PID controllers provide stable parameter adjustments
-4. **Safety Limits**: All adaptive behavior is constrained by configurable limits
-5. **Observable Decisions**: All adaptation decisions are exposed as metrics
+1. **Separation of Concerns** – Data processing and control logic run in separate pipelines
+2. **Self-Adaptation** – The system automatically adjusts to changing conditions
+3. **Feedback Control** – PID controllers provide stable parameter adjustments
+4. **Safety Limits** – All adaptive behaviour is constrained by configurable limits
+5. **Observable Decisions** – All adaptation decisions are exposed as metrics
 
-## Detailed Component Relationships
+## Component Relationships
 
 ```
-                ┌──────────────────────────────────────────┐
-                │        Host / App  Metrics (OTLP)        │
-                └──────┬────────────────────────────────────┘
-                       │
-       ┌───────────────▼───────────────┐
-       │  Phoenix Data  Pipeline        │
-       │ (Adaptive Processors:         │
-       │  - PriorityTagger             │
-       │  - AdaptiveTopK               │
-       │  - OthersRollup)              │
-       └───────────────┬───────────────┘
-                       │ Self-Metrics
-                       ▼
-       ┌──────────────────────────────────────────┐
-       │        Phoenix Control Pipeline          │
-       │  (Processors:                            │
-       │   - AdaptivePID: PID → Bayesian Logic)   │
-       │  (Outputs: ConfigPatch Objects)          │
-       └──────────────────────┬───────────────────┘
-                              │ ConfigPatch
-                              ▼
-                 ┌───────────────────────────┐
-                 │ PIC Control Extension      │
-                 └───────────────┬───────────┘
-                                 │ OnConfigPatch
-                                 ▼
-                 ┌───────────────────────────┐
-                 │ UpdateableProcessor.apply  │
-                 └───────────────────────────┘
+                ┌──────────────────────────────┐
+                │  Host / App Metrics (OTLP)   │
+                └──────────────┬───────────────┘
+                               │
+               ┌───────────────▼───────────────┐
+               │    Phoenix Data Pipeline      │
+               │       metric_pipeline         │
+               └───────────────┬───────────────┘
+                               │ Self-Metrics
+                               ▼
+               ┌──────────────────────────────┐
+               │    Control Pipeline          │
+               │     adaptive_pid             │
+               └───────────────┬──────────────┘
+                               │ ConfigPatch
+                               ▼
+               ┌──────────────────────────────┐
+               │ metric_pipeline.OnConfigPatch│
+               └──────────────────────────────┘
 ```
 
 ## Safety Mechanisms
 
 Phoenix includes several built-in safety mechanisms:
 
-1. **PID Controller Safeguards**:
+1. **PID Controller Safeguards**
    - Anti-windup protection prevents integral term saturation
    - Derivative filtering reduces noise sensitivity
    - Circuit breakers detect and mitigate oscillation
    - Output clamping ensures parameters stay within bounds
 
-2. **System-Level Safeguards**:
+2. **System-Level Safeguards**
    - Resource usage monitoring (CPU, memory)
    - Automatic safe mode activation under high resource pressure
    - Graduated adaptation response for smoother transitions
@@ -93,14 +77,12 @@ Phoenix includes several built-in safety mechanisms:
 
 The core architectural decisions are documented in Architecture Decision Records (ADRs):
 
-1. [ADR-001: Dual-Pipeline Architecture](adr/001-dual-pipeline-architecture.md) - Establishes the separation between data and control pipelines
-2. [ADR-002: Self-Regulating PID Control](adr/20250519-use-self-regulating-pid-control-for-adaptive-processing.md) - Details the decision to use PID controllers for adaptation
+1. [ADR-001: Dual-Pipeline Architecture](adr/001-dual-pipeline-architecture.md) – Establishes the separation between data and control pipelines
+2. [ADR-002: Self-Regulating PID Control](adr/20250519-use-self-regulating-pid-control-for-adaptive-processing.md) – Details the decision to use PID controllers for adaptation
 
 ## Implementation Notes
 
-Current implementation considerations:
-
-1. **UpdateableProcessor Interface**: The core interface that allows processors to receive configuration updates:
+1. **UpdateableProcessor Interface** – allows processors to receive configuration updates:
    ```go
    type UpdateableProcessor interface {
        OnConfigPatch(ctx context.Context, patch *ConfigPatch) error
@@ -108,16 +90,14 @@ Current implementation considerations:
    }
    ```
 
-2. **Configuration Flow**:
-   - Configuration originates in the `policy.yaml` file
-   - PID controllers in `adaptive_pid` processor calculate adjustments
-   - Changes flow through the system as `ConfigPatch` objects
-   - `pic_control_ext` validates and applies changes to processors
+2. **Configuration Flow**
+   - Configuration originates in `policy.yaml`
+   - The `adaptive_pid` processor computes adjustments based on self-metrics
+   - Patches are applied directly to the `metric_pipeline` processor
 
-3. **Metrics Flow**:
+3. **Metrics Flow**
    - Processors emit self-metrics with the `aemf_` prefix
-   - Control pipeline monitors these metrics to calculate KPIs
-   - Metrics become inputs to PID controllers
-   - System also exports standard OTel metrics with the `otelcol_` prefix
+   - The control pipeline monitors these metrics to calculate KPIs
+   - The system also exports standard OTel metrics with the `otelcol_` prefix
 
-For detailed documentation on specific components, please see the [Components Documentation](../components/README.md).
+For detailed documentation on specific components, see the [Components Documentation](../components/README.md).

--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -28,11 +28,7 @@ All processors implement the `UpdateableProcessor` interface which allows them t
 
 ### Extensions
 
-Extensions provide additional functionality outside the data path:
-
-| Extension | Description | Status |
-|-----------|-------------|--------|
-| [pic_control_ext](./extensions/pic_control_ext.md) | Central governance layer for config changes | Implemented |
+There are currently no extensions shipped with Phoenix. This section is reserved for future components that may operate outside the data pipeline.
 
 ### Connectors
 
@@ -80,15 +76,8 @@ Phoenix implements a dual pipeline architecture that separates data processing f
         │                          │
         ▼                          ▼
 ┌───────────────┐          ┌───────────────┐
-│  Exporters    │          │ pic_control   │
-└───────────────┘          │   extension   │
-                           └───────┬───────┘
-                                   │
-                                   ▼
-                           ┌───────────────┐
-                           │ Configuration │
-                           │    Patches    │
-                           └───────┬───────┘
+│  Exporters    │          │ ConfigPatch   │
+└───────────────┘          └───────┬───────┘
                                    │
                                    ▼
                            ┌───────────────┐

--- a/docs/components/extensions/README.md
+++ b/docs/components/extensions/README.md
@@ -6,7 +6,7 @@ This directory contains documentation for the extensions implemented in SA-OMF.
 
 | Extension | Description | Status |
 |-----------|-------------|--------|
-| pic_control_ext | Central governance layer for configuration changes | Implemented |
+Currently no extensions are included in the distribution.
 
 ## Extension Concepts
 

--- a/docs/components/processor/metric_pipeline.md
+++ b/docs/components/processor/metric_pipeline.md
@@ -1,6 +1,6 @@
 # Metric Pipeline Processor
 
-The `metric_pipeline` processor is a unified processor that combines resource filtering and metric transformation into a single processing step. It replaces multiple separate processors (priority_tagger, adaptive_topk, others_rollup, and attribute processors) to improve performance and simplify configuration.
+The `metric_pipeline` processor combines resource filtering and metric transformation into a single processing step. This unified design improves performance and simplifies configuration.
 
 ## Architecture
 
@@ -142,7 +142,7 @@ The processor implements the `UpdateableProcessor` interface, allowing its confi
 - Threshold adjustments for prioritization
 - On-the-fly changes to attribute handling and histogram configuration
 
-Configuration patches can be applied programmatically or through the pic_control extension.
+Configuration patches can be applied programmatically through the collector API.
 
 ## Performance Considerations
 
@@ -220,23 +220,3 @@ processors:
             action: "insert"
             value: {{ .Resource.Attributes.GetString "aemf.process.priority" "unknown" }}
 ```
-
-## Comparison with Individual Processors
-
-The `metric_pipeline` processor replaces and consolidates the following processors:
-
-1. **priority_tagger**: 
-   - *Before*: Tagged resources with priority levels based on regex patterns.
-   - *Now*: Handled by the `resource_filter` with `priority_rules`.
-
-2. **adaptive_topk**:
-   - *Before*: Selected top K resources based on a metric value.
-   - *Now*: Handled by the `resource_filter` with `topk` configuration, with K values adjustable via adaptive_pid.
-
-3. **others_rollup**:
-   - *Before*: Aggregated metrics for non-priority processes.
-   - *Now*: Handled by the `resource_filter` with `rollup` configuration.
-
-4. **attributes** processor and **histogram_aggregator**:
-   - *Before*: Separate processors for attribute manipulation and histogram generation.
-   - *Now*: Integrated into the `transformation` section of the metric_pipeline.

--- a/docs/components/processors/adaptive_pid.md
+++ b/docs/components/processors/adaptive_pid.md
@@ -14,9 +14,7 @@ This processor:
 
 ## Current Implementation
 
-> **Important Note**: This processor has evolved from its original design. In the current implementation, it functions as a self-contained adaptive component rather than generating configuration patches for other processors.
-
-Each adaptive processor (like adaptive_topk, others_rollup) now implements its own adaptation mechanisms internally, making the system more modular and simpler to maintain.
+> **Important Note**: This processor has evolved from its original design. It now functions as a self-contained adaptive component rather than generating configuration patches for other processors.
 
 ## Configuration
 

--- a/docs/integrations/new-relic-otlp-export.md
+++ b/docs/integrations/new-relic-otlp-export.md
@@ -10,6 +10,16 @@ The configuration optimizes for:
 3. **Adaptive filtering**: Prioritizes important processes using PID control
 4. **Histogram optimization**: Ensures histograms are formatted optimally for New Relic
 
+## Process-Metrics OTLP Model
+
+Phoenix exports process metrics using a streamlined OTLP schema tailored for New Relic. Metrics are emitted from the `metric_pipeline` processor with a minimal set of attributes:
+
+- `service.name` identifies the host or service
+- `phoenix.priority` records the assigned priority level
+- `collector.name` is set to `phoenix-sa-omf`
+
+Low-priority processes are aggregated into rollup metrics prefixed with `phoenix.others.process`. CPU and memory metrics are converted to histograms so New Relic can render them effectively.
+
 ## Prerequisites
 
 1. A New Relic account with Metrics API access


### PR DESCRIPTION
## Summary
- rewrite architecture README for single metric_pipeline and direct patching
- remove references to obsolete processors and pic_control extension
- document process-metrics OTLP model for New Relic

## Testing
- `make test` *(fails: module downloads disabled)*