### PR TITLE
Simplify collector configs

### DIFF
--- a/configs/default/config.yaml
+++ b/configs/default/config.yaml
@@ -1,20 +1,12 @@
-extensions:
-  pic_control:
-    policy_file_path: /etc/sa-omf/policy.yaml
-    max_patches_per_minute: 3
-    patch_cooldown_seconds: 10
-
 receivers:
   hostmetrics:
     collection_interval: 10s
     scrapers:
-      # Only include process metrics to reduce cardinality
       process:
         include:
           match_type: regexp
           processes: [".*"]
         resource_attributes:
-          # Include only necessary process attributes
           process.executable.name: true
           process.executable.path: false
           process.command: false
@@ -22,132 +14,21 @@ receivers:
           process.pid: true
           process.parent_pid: false
           process.owner: true
-  
-  # Receiver for self-metrics collection
-  prometheus/self:
-    config:
-      scrape_configs:
-        - job_name: 'sa-omf-self'
-          scrape_interval: 5s
-          static_configs:
-            - targets: ['localhost:8888']
 
 processors:
-  # Processors will be configured from policy.yaml
-  # This separation ensures that dynamic config lives in policy file
-  # while pipeline structure lives here
-  
-  # Unified resource filter processor that combines the functionality of
-  # priority_tagger, adaptive_topk, and others_rollup
-  resource_filter:
-    enabled: true
-    filter_strategy: hybrid
-    priority_attribute: "aemf.process.priority"
-    priority_rules:
-      - match: "process.executable.name=~/java|javaw/"
-        priority: high
-      - match: "process.executable.name=~/nginx|httpd|apache2/"
-        priority: high
-      - match: "process.executable.name=~/mysql|postgres|mongod|redis-server|elasticsearch/"
-        priority: critical
-      - match: "process.executable.name=~/python|python3|node|dotnet|ruby/"
-        priority: medium
-      - match: "process.executable.name=~/otelcol|sa-omf-otelcol|collector/"
-        priority: critical
-      - match: "process.executable.name=~/newrelic-infra|nri-.*/"
-        priority: critical
-      - match: ".*"
-        priority: low
-    topk:
-      k_value: 20
-      k_min: 10
-      k_max: 40
-      resource_field: "process.executable.name"
-      counter_field: "process.cpu.utilization"
-      coverage_target: 0.95
-    rollup:
-      enabled: true
-      priority_threshold: low
-      strategy: sum
-      name_prefix: "others"
-  
-  # Histogram aggregator to optimize histogram metrics for OTLP export
-  histogram_aggregator:
-    enabled: true
-    max_buckets: 10
-    target_processors: []  # Empty means apply to all processes
-    custom_boundaries:
-      process.memory.usage:
-        - 10000000  # 10MB
-        - 50000000  # 50MB  
-        - 100000000 # 100MB
-        - 500000000 # 500MB
-        - 1000000000 # 1GB
-      process.cpu.time:
-        - 0.1
-        - 0.5
-        - 1.0
-        - 5.0
-        - 10.0
-  
-  # Attribute processor to control cardinality by filtering metrics attributes
-  attributes/process:
-    actions:
-      # Include only essential attributes to reduce cardinality
-      - key: process.executable.name
-        action: update
-        value: {{ if eq .Value.String "unknown" }}default{{ else }}{{ .Value.String }}{{ end }}
-      # Remove unnecessary attributes that increase cardinality
-      - key: process.command_line
-        action: delete
-      - key: process.command
-        action: delete
-      - key: process.executable.path
-        action: delete
-      # Add New Relic compatibility attributes
-      - key: collector.name
-        action: insert
-        value: "SA-OMF"
-      - key: service.name
-        action: insert
-        value: {{ .Resource.Attributes.GetString "process.executable.name" "unknown" }}
+  metric_pipeline:
 
 exporters:
   logging:
     verbosity: detailed
-  
-  prometheusremotewrite:
-    endpoint: "http://localhost:9090/api/v1/write"
-    timeout: 5s
-
   otlp:
-    endpoint: "https://otlp.nr-data.net:4317"  # New Relic OTLP endpoint
+    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
     headers:
-      api-key: "${env:NEW_RELIC_API_KEY}"  # API key from environment variable
-    timeout: 10s
-    sending_queue:
-      enabled: true
-      num_consumers: 4
-      queue_size: 100
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_interval: 30s
-      max_elapsed_time: 300s
-
-  pic_connector:
-    # PIC connector forwards config patches to pic_control extension
+      api-key: "${env:NEW_RELIC_API_KEY}"
 
 service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [resource_filter, histogram_aggregator, attributes/process]
-      exporters: [logging, prometheusremotewrite, otlp]
-    
-    control:
-      receivers: [prometheus/self]
-      processors: [adaptive_pid]
-      exporters: [pic_connector]
-  
-  extensions: [pic_control]
+      processors: [metric_pipeline]
+      exporters: [logging, otlp]

--- a/configs/default/simplified_config.yaml
+++ b/configs/default/simplified_config.yaml
@@ -1,20 +1,12 @@
-extensions:
-  pic_control:
-    policy_file_path: /etc/sa-omf/policy.yaml
-    max_patches_per_minute: 3
-    patch_cooldown_seconds: 10
-
 receivers:
   hostmetrics:
     collection_interval: 10s
     scrapers:
-      # Only include process metrics to reduce cardinality
       process:
         include:
           match_type: regexp
           processes: [".*"]
         resource_attributes:
-          # Include only necessary process attributes
           process.executable.name: true
           process.executable.path: false
           process.command: false
@@ -22,139 +14,21 @@ receivers:
           process.pid: true
           process.parent_pid: false
           process.owner: true
-  
-  # Receiver for self-metrics collection
-  prometheus/self:
-    config:
-      scrape_configs:
-        - job_name: 'sa-omf-self'
-          scrape_interval: 5s
-          static_configs:
-            - targets: ['localhost:8888']
 
 processors:
-  # Combined processor for resource filtering and metric transformation
-  # This single processor replaces multiple separate processors for better efficiency
   metric_pipeline:
-    # Resource filtering configuration (consolidates priority_tagger, adaptive_topk, others_rollup)
-    resource_filter:
-      enabled: true
-      filter_strategy: hybrid
-      priority_attribute: "aemf.process.priority"
-      priority_rules:
-        - match: "process.executable.name=~/java|javaw/"
-          priority: high
-        - match: "process.executable.name=~/nginx|httpd|apache2/"
-          priority: high
-        - match: "process.executable.name=~/mysql|postgres|mongod|redis-server|elasticsearch/"
-          priority: critical
-        - match: "process.executable.name=~/python|python3|node|dotnet|ruby/"
-          priority: medium
-        - match: "process.executable.name=~/otelcol|sa-omf-otelcol|collector/"
-          priority: critical
-        - match: "process.executable.name=~/newrelic-infra|nri-.*/"
-          priority: critical
-        - match: ".*"
-          priority: low
-      topk:
-        k_value: 20
-        k_min: 10
-        k_max: 40
-        resource_field: "process.executable.name"
-        counter_field: "process.cpu.utilization"
-        coverage_target: 0.95
-      rollup:
-        enabled: true
-        priority_threshold: low
-        strategy: sum
-        name_prefix: "others"
-    
-    # Metric transformation configuration
-    transformation:
-      # Histogram generation
-      histograms:
-        enabled: true
-        max_buckets: 10
-        metrics:
-          process.memory.usage:
-            boundaries:
-              - 10000000  # 10MB
-              - 50000000  # 50MB  
-              - 100000000 # 100MB
-              - 500000000 # 500MB
-              - 1000000000 # 1GB
-          process.cpu.time:
-            boundaries:
-              - 0.1
-              - 0.5
-              - 1.0
-              - 5.0
-              - 10.0
-      
-      # Attribute processing
-      attributes:
-        actions:
-          # Include only essential attributes to reduce cardinality
-          - key: process.executable.name
-            action: update
-            value: {{ if eq .Value.String "unknown" }}default{{ else }}{{ .Value.String }}{{ end }}
-          # Remove unnecessary attributes that increase cardinality
-          - key: process.command_line
-            action: delete
-          - key: process.command
-            action: delete
-          - key: process.executable.path
-            action: delete
-          # Add New Relic compatibility attributes
-          - key: collector.name
-            action: insert
-            value: "SA-OMF"
-          - key: service.name
-            action: insert
-            value: {{ .Resource.Attributes.GetString "process.executable.name" "unknown" }}
 
 exporters:
   logging:
     verbosity: detailed
-  
-  # Export to Prometheus for internal monitoring
-  prometheusremotewrite:
-    endpoint: "http://localhost:9090/api/v1/write"
-    timeout: 5s
-
-  # Export to New Relic
   otlp:
-    endpoint: "https://otlp.nr-data.net:4317"
+    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
     headers:
       api-key: "${env:NEW_RELIC_API_KEY}"
-    timeout: 10s
-    sending_queue:
-      enabled: true
-      num_consumers: 4
-      queue_size: 100
-    retry_on_failure:
-      enabled: true
-      initial_interval: 5s
-      max_interval: 30s
-      max_elapsed_time: 300s
-
-  pic_connector:
-    # PIC connector forwards config patches to pic_control extension
 
 service:
-  # Simplified pipeline structure with one main pipeline for data processing
-  # and one control pipeline for self-regulation
   pipelines:
-    # Main data pipeline
     metrics:
       receivers: [hostmetrics]
       processors: [metric_pipeline]
-      exporters: [logging, prometheusremotewrite, otlp]
-    
-    # Control pipeline for self-regulation
-    control:
-      receivers: [prometheus/self]
-      processors: [adaptive_pid]
-      exporters: [pic_connector]
-  
-  extensions: [pic_control]
+      exporters: [logging, otlp]

--- a/configs/development/config.yaml
+++ b/configs/development/config.yaml
@@ -1,31 +1,11 @@
-extensions:
-  pic_control:
-    policy_file_path: ./configs/development/policy.yaml # Relative path for local dev convenience
-    max_patches_per_minute: 10  # Higher for development to see effects faster
-    patch_cooldown_seconds: 2   # Shorter for development
-
 receivers:
   hostmetrics:
     collection_interval: 5s  # Faster for development environment
     scrapers:
-      cpu:
-      memory:
-      load:
-      filesystem:
-      network:
-      paging:
       process:
         include:
           match_type: regexp
           processes: [".*"]
-  
-  prometheus/self:
-    config:
-      scrape_configs:
-        - job_name: 'sa-omf-self'
-          scrape_interval: 2s  # Faster for development
-          static_configs:
-            - targets: ['localhost:8888']
 
 processors:
   # Processors configured via policy.yaml
@@ -33,24 +13,14 @@ processors:
 exporters:
   logging:
     verbosity: detailed  # Detailed logs for development
-  
-  prometheusremotewrite:
-    endpoint: "http://localhost:9090/api/v1/write"
-    timeout: 5s
-  
-  pic_connector: {}
+  otlp:
+    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
+    headers:
+      api-key: "${env:NEW_RELIC_API_KEY}"
 
 service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [priority_tagger, adaptive_topk, others_rollup]
-      exporters: [logging, prometheusremotewrite]
-    
-    control:
-      receivers: [prometheus/self]
-      processors: [adaptive_pid]
-      exporters: [pic_connector, logging]
-  
-  extensions: [pic_control]
-
+      processors: [metric_pipeline]
+      exporters: [logging, otlp]

--- a/configs/examples/config.yaml
+++ b/configs/examples/config.yaml
@@ -1,75 +1,26 @@
-extensions:
-  pic_control:
-    policy_file_path: /etc/sa-omf/policy.yaml # Example, typically overridden by example-specific policy.yaml
-    max_patches_per_minute: 3
-    patch_cooldown_seconds: 10
-    safe_mode_processor_configs:
-      adaptive_topk:
-        k_value: 10
-
 receivers:
   hostmetrics:
     collection_interval: 10s
     scrapers:
-      cpu:
-      memory:
-      load:
-      filesystem:
-      network:
-      paging:
       process:
         include:
           match_type: regexp
           processes: [".*"]
 
 processors:
-  priority_tagger:
-    enabled: true
-    rules:
-      - match: "process.command_line=~/.*java.*/"
-        priority: high
-      - match: "process.name=~/nginx|httpd/"
-        priority: high
-      - match: "process.name=~/mysql|postgres|mongodb/"
-        priority: critical
-      - match: "process.command_line=~/.*python.*/"
-        priority: medium
-      - match: ".*"
-        priority: low
-  
-  pid_decider:
-    controllers:
-      - name: coverage_controller
-        enabled: true
-        kpi_metric_name: aemf_impact_adaptive_topk_resource_coverage_percent_avg_1m
-        kpi_target_value: 0.90
-        kp: 30
-        ki: 5
-        kd: 0
-        hysteresis_percent: 3
-        output_config_patches:
-          - target_processor_name: adaptive_topk
-            parameter_path: k_value
-            change_scale_factor: -20.0
-            min_value: 10
-            max_value: 60
+  metric_pipeline:
 
 exporters:
   logging:
     verbosity: detailed
-  pic_connector: {}
+  otlp:
+    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
+    headers:
+      api-key: "${env:NEW_RELIC_API_KEY}"
 
 service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [priority_tagger]
-      exporters: [logging]
-    
-    control:
-      receivers: [hostmetrics]
-      processors: [pid_decider]
-      exporters: [pic_connector, logging]
-  
-  extensions: [pic_control]
-
+      processors: [metric_pipeline]
+      exporters: [logging, otlp]

--- a/configs/process_metrics/config.yaml
+++ b/configs/process_metrics/config.yaml
@@ -1,10 +1,3 @@
-extensions:
-  pic_control:
-    policy_file_path: /etc/sa-omf/process_metrics/policy.yaml
-    max_patches_per_minute: 5
-    patch_cooldown_seconds: 5
-    auto_apply_patches: true  # Enable automatic application of patches
-
 receivers:
   # Process metrics collection - exclusively focus on process scraper
   hostmetrics:
@@ -164,8 +157,8 @@ exporters:
     sampling_thereafter: 100  # Then log every 100th
 
   # Export to New Relic through OTLP
-  otlphttp/newrelic:
-    endpoint: "https://otlp.nr-data.net:4318"  # Use HTTP endpoint (4318) for maximum compatibility
+  otlp:
+    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
     headers:
       api-key: "${env:NEW_RELIC_API_KEY}"
     timeout: 10s
@@ -181,10 +174,6 @@ exporters:
       queue_size: 1000  # Larger queue to handle bursts
     disable_metrics_histograms: false  # Make sure histograms are enabled for New Relic
 
-  # Connector for configuration patching
-  pic_connector:
-    # PIC connector forwards config patches to pic_control extension
-
 # Create a dual-pipeline system to ensure reliability
 service:
   pipelines:
@@ -193,23 +182,15 @@ service:
       receivers: [hostmetrics]
       # Process flow: Convert CPU counters to delta → Process with unified metric pipeline → Batch for efficiency
       processors: [cumulativetodelta, metric_pipeline, batch]
-      exporters: [logging, otlphttp/newrelic]
+      exporters: [logging, otlp]
     
     # Self-metrics pipeline to export Phoenix's own metrics to New Relic
     # This allows monitoring the performance and behavior of Phoenix itself
     metrics/phoenix_self:
       receivers: [prometheus/self]
-      processors: [batch]
-      exporters: [otlphttp/newrelic]
+      processors: [metric_pipeline, batch]
+      exporters: [otlp]
     
-    # Control pipeline for self-regulation
-    control:
-      receivers: [prometheus/self]
-      processors: [adaptive_pid]
-      exporters: [pic_connector]
-  
-  extensions: [pic_control]
-
 # Telemetry for the collector itself
 telemetry:
   metrics:

--- a/configs/process_metrics/examples/processors_config.yaml
+++ b/configs/process_metrics/examples/processors_config.yaml
@@ -1,10 +1,3 @@
-extensions:
-  pic_control:
-    policy_file_path: /etc/sa-omf/process_metrics/policy.yaml
-    max_patches_per_minute: 5
-    patch_cooldown_seconds: 5
-    auto_apply_patches: true  # Enable automatic application of patches
-
 receivers:
   # Process metrics collection - exclusively focus on process scraper
   hostmetrics:
@@ -15,11 +8,10 @@ receivers:
           match_type: regexp
           processes: [".*"]  # Collect metrics for all processes
         metrics:
-          # Explicitly list only the needed process metrics to minimize overhead
           process.cpu.time: true
           process.memory.rss: true
           process.threads: true
-  
+
   # Self-metrics collection
   prometheus/self:
     config:
@@ -38,34 +30,14 @@ processors:
       metrics:
         - process.cpu.time
     max_stale: 15s
-  
+
   # Batch metrics for efficient export
   batch:
     send_batch_size: 1000
     send_batch_max_size: 2000
     timeout: 5s
-  
-  # Timeseries estimator processor to track active time series
-  timeseries_estimator:
-    enabled: true
-    output_metric_name: "aemf_estimated_active_timeseries"
-    estimator_type: "hll"
-    hll_precision: 10
-    memory_limit_mb: 100
-    refresh_interval: 1h
 
-  # CPU histogram converter processor to generate CPU utilization histograms
-  cpu_histogram_converter:
-    enabled: true
-    input_metric_name: "process.cpu.time"
-    output_metric_name: "process.cpu.utilization.histogram"
-    collection_interval_seconds: 10
-    host_cpu_count: 0  # Auto-detect
-    top_k_only: false
-    histogram_buckets: [0.1, 0.5, 1, 2, 5, 10, 25, 50, 75, 100, 200, 400, 800]
-    state_storage_path: "/var/lib/sa-omf/cpu_histogram_state" # Persistent state
-    state_flush_interval_seconds: 300
-    max_processes_in_memory: 10000
+  metric_pipeline:
 
 exporters:
   # Detailed logging for development and debugging
@@ -75,8 +47,8 @@ exporters:
     sampling_thereafter: 100  # Then log every 100th
 
   # Export to New Relic through OTLP
-  otlphttp/newrelic:
-    endpoint: "https://otlp.nr-data.net:4318"  # Use HTTP endpoint (4318) for maximum compatibility
+  otlp:
+    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
     headers:
       api-key: "${env:NEW_RELIC_API_KEY}"
     timeout: 10s
@@ -87,35 +59,20 @@ exporters:
       max_interval: 30s
       max_elapsed_time: 300s
 
-  # Connector for configuration patching
-  pic_connector:
-    # PIC connector forwards config patches to pic_control extension
-
-# Create a pipeline system with our new processors
 service:
   pipelines:
     # Main process metrics pipeline
     metrics/process:
       receivers: [hostmetrics]
-      # Process flow: Convert CPU counters to delta → Process with both new processors → Batch for efficiency
-      processors: [cumulativetodelta, timeseries_estimator, cpu_histogram_converter, batch]
-      exporters: [logging, otlphttp/newrelic]
-    
+      processors: [cumulativetodelta, metric_pipeline, batch]
+      exporters: [logging, otlp]
+
     # Self-metrics pipeline to export Phoenix's own metrics
     metrics/phoenix_self:
       receivers: [prometheus/self]
-      processors: [batch]
-      exporters: [otlphttp/newrelic]
-    
-    # Control pipeline for self-regulation
-    control:
-      receivers: [prometheus/self]
-      processors: [adaptive_pid]
-      exporters: [pic_connector]
-  
-  extensions: [pic_control]
+      processors: [metric_pipeline, batch]
+      exporters: [otlp]
 
-# Telemetry for the collector itself
 telemetry:
   metrics:
     address: localhost:8888

--- a/configs/production/config.yaml
+++ b/configs/production/config.yaml
@@ -1,31 +1,11 @@
-extensions:
-  pic_control:
-    policy_file_path: /etc/sa-omf/policy.yaml # Path inside the container / expected by service
-    max_patches_per_minute: 3
-    patch_cooldown_seconds: 10
-
 receivers:
   hostmetrics:
     collection_interval: 10s
     scrapers:
-      cpu:
-      memory:
-      load:
-      filesystem:
-      network:
-      paging:
       process:
         include:
           match_type: regexp
           processes: [".*"]
-  
-  prometheus/self:
-    config:
-      scrape_configs:
-        - job_name: 'sa-omf-self'
-          scrape_interval: 5s
-          static_configs:
-            - targets: ['localhost:8888']
 
 processors:
   # Processors configured via policy.yaml
@@ -33,24 +13,14 @@ processors:
 exporters:
   logging:
     verbosity: detailed
-  
-  prometheusremotewrite:
-    endpoint: "http://localhost:9090/api/v1/write"
-    timeout: 5s
-  
-  pic_connector: {}
+  otlp:
+    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
+    headers:
+      api-key: "${env:NEW_RELIC_API_KEY}"
 
 service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [priority_tagger, adaptive_topk, others_rollup]
-      exporters: [logging, prometheusremotewrite]
-    
-    control:
-      receivers: [prometheus/self]
-      processors: [adaptive_pid]
-      exporters: [pic_connector, logging]
-  
-  extensions: [pic_control]
-
+      processors: [metric_pipeline]
+      exporters: [logging, otlp]

--- a/configs/testing/config.yaml
+++ b/configs/testing/config.yaml
@@ -1,31 +1,11 @@
-extensions:
-  pic_control:
-    policy_file_path: /etc/sa-omf/policy.yaml
-    max_patches_per_minute: 5  # Higher rate for testing
-    patch_cooldown_seconds: 2  # Shorter cooldown for testing
-
 receivers:
   hostmetrics:
     collection_interval: 5s  # Faster collection for testing
     scrapers:
-      cpu:
-      memory:
-      load:
-      filesystem:
-      network:
-      paging:
       process:
         include:
           match_type: regexp
           processes: [".*"]
-  
-  prometheus/self:
-    config:
-      scrape_configs:
-        - job_name: 'sa-omf-self'
-          scrape_interval: 2s  # Faster for testing
-          static_configs:
-            - targets: ['localhost:8888']
 
 processors:
   # Processors configured via policy.yaml
@@ -33,24 +13,14 @@ processors:
 exporters:
   logging:
     verbosity: detailed
-  
-  prometheusremotewrite:
-    endpoint: "http://localhost:9090/api/v1/write"
-    timeout: 5s
-  
-  pic_connector: {}
+  otlp:
+    endpoint: "${env:NEW_RELIC_OTLP_ENDPOINT}"
+    headers:
+      api-key: "${env:NEW_RELIC_API_KEY}"
 
 service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      processors: [priority_tagger, adaptive_topk, others_rollup]
-      exporters: [logging, prometheusremotewrite]
-    
-    control:
-      receivers: [prometheus/self]
-      processors: [adaptive_pid]
-      exporters: [pic_connector]
-  
-  extensions: [pic_control]
-
+      processors: [metric_pipeline]
+      exporters: [logging, otlp]


### PR DESCRIPTION
## Summary
- drop pic_control and prometheusremotewrite from all configs
- keep only process scraper and use metric_pipeline in pipelines
- configure OTLP exporter via env vars

## Testing
- `make test` *(fails: module download disabled)*