### PR TITLE
Fix go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/deepaucksharma/Phoenix
 
-go 1.23.8
+go 1.23


### PR DESCRIPTION
## Summary
- use a valid Go version in `go.mod`

## Testing
- `go mod tidy` *(fails: no route to host)*