### PR TITLE
Add Go and Node tests with CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,23 @@ jobs:
         run: |
           sha256sum -c CHECKSUMS.txt || echo "Warning: Checksum mismatch detected"
 
+  test-js:
+    name: Test JS/TS Packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+
   test-go:
     name: Test Go Services
     runs-on: ubuntu-latest
@@ -64,7 +81,7 @@ jobs:
   test-integration:
     name: Integration Tests
     runs-on: ubuntu-latest
-    needs: [validate, test-go]
+    needs: [validate, test-go, test-js]
     steps:
       - uses: actions/checkout@v4
       
@@ -116,7 +133,7 @@ jobs:
   build:
     name: Build Docker Images
     runs-on: ubuntu-latest
-    needs: [test-go, test-integration]
+    needs: [test-go, test-js, test-integration]
     strategy:
       matrix:
         service:

--- a/apps/anomaly-detector/main_test.go
+++ b/apps/anomaly-detector/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestStatisticalDetectorDetect(t *testing.T) {
+	detector := &StatisticalDetector{windowSize: 5, threshold: 2.0}
+	now := time.Now()
+	points := []DataPoint{}
+	for i := 0; i < 5; i++ {
+		points = append(points, DataPoint{Timestamp: now.Add(time.Duration(i) * time.Minute), Value: 100})
+	}
+	// anomaly point far from mean
+	points = append(points, DataPoint{Timestamp: now.Add(6 * time.Minute), Value: 150})
+
+	metrics := map[string][]DataPoint{"metric": points}
+	anomalies, err := detector.Detect(context.Background(), metrics)
+	if err != nil {
+		t.Fatalf("detect returned error: %v", err)
+	}
+	if len(anomalies) == 0 {
+		t.Fatalf("expected at least one anomaly")
+	}
+	if anomalies[0].DetectorName != detector.GetName() {
+		t.Errorf("unexpected detector name %s", anomalies[0].DetectorName)
+	}
+}

--- a/apps/control-actuator-go/main_test.go
+++ b/apps/control-actuator-go/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func TestCalculateMode(t *testing.T) {
+	cl := &ControlLoop{
+		conservativeMax:  100,
+		aggressiveMin:    200,
+		hysteresisFactor: 0.1,
+		currentMode:      Balanced,
+	}
+
+	if mode := cl.calculateMode(80, -1); mode != Conservative {
+		t.Errorf("expected %s, got %s", Conservative, mode)
+	}
+
+	if mode := cl.calculateMode(220, 1); mode != Aggressive {
+		t.Errorf("expected %s, got %s", Aggressive, mode)
+	}
+
+	if mode := cl.calculateMode(150, 0); mode != Balanced {
+		t.Errorf("expected %s, got %s", Balanced, mode)
+	}
+
+	cl.currentMode = Aggressive
+	if mode := cl.calculateMode(190, -1); mode != Balanced {
+		t.Errorf("expected %s due to hysteresis, got %s", Balanced, mode)
+	}
+
+	cl.currentMode = Conservative
+	if mode := cl.calculateMode(105, -1); mode != Conservative {
+		t.Errorf("expected %s to remain due to hysteresis, got %s", Conservative, mode)
+	}
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@changesets/cli": "^2.27.0",
     "eslint": "^8.54.0",
     "prettier": "^3.1.0",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "jest": "^29.6.0"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/contracts/__tests__/schema.test.js
+++ b/packages/contracts/__tests__/schema.test.js
@@ -1,0 +1,6 @@
+const schema = require('../schemas/control_signal.json');
+
+test('schema has mode enum', () => {
+  expect(schema.properties).toHaveProperty('mode');
+  expect(schema.properties.mode.enum).toContain('balanced');
+});

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/google-protobuf": "^3.15.10",
     "protoc-gen-ts": "^0.8.7",
-    "typescript": "^5.3.0"
+    "typescript": "^5.3.0",
+    "jest": "^29.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- add unit tests for calculateMode and statistical anomaly detection
- provide a small Jest test for contracts package
- configure Jest at the repo root
- add JS testing job to CI workflow
- include Jest as a dev dependency

## Testing
- `go test ./...` *(fails: malformed go.sum)*
- `npm test --silent` *(fails: turbo not found)*