### PR TITLE
Fix docs referencing nonexistent archive

### DIFF
--- a/docs/CONSOLIDATION_SUMMARY.md
+++ b/docs/CONSOLIDATION_SUMMARY.md
@@ -17,13 +17,12 @@ This document summarizes the markdown file consolidation completed on 2025-05-24
 - `scripts/consolidated/README.md` - Scripts organization guide  
 - `packages/go-common/README.md` - Go packages documentation
 
-### Archived Documentation (19 files)
-- `docs/archive/` - Contains 13 original temporary files
-- `docs/archive/reports-2025-05-24/` - Contains 6 historical reports
+### Archived Documentation (19 files) [removed]
+The consolidation originally placed historical files in a now-removed `docs/archive/` directory containing 19 documents.
 
 ## Actions Taken
 
-1. **Moved to Archive**: 6 historical documents moved from docs/ to archive/reports-2025-05-24/
+1. **Moved to Archive** (later removed): 6 historical documents were initially moved from `docs/` to `archive/reports-2025-05-24/`
    - CLEANUP_SUMMARY.md
    - COMPLETE_SOLUTION_REVIEW.md
    - MONOREPO_MODULARITY_REVIEW.md
@@ -34,12 +33,12 @@ This document summarizes the markdown file consolidation completed on 2025-05-24
 2. **Updated Documentation Hub**: docs/README.md now includes:
    - Key system information (ports, performance targets)
    - Clear links to all documentation
-   - Reference to archived materials
+   - Reference to archived materials (folder later deleted)
 
 3. **Preserved Component Docs**: Keep README files that document specific components
 
 ## Result
 - **Before**: 25 markdown files scattered across the project
-- **After**: 6 active documentation files + 19 archived files
+- **After**: 6 active documentation files
 - **Reduction**: 76% fewer files in active documentation paths
 - **Organization**: Clear separation between current and historical documentation

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,8 +47,6 @@ This directory contains documentation for the Phoenix v3 Cardinality Optimizatio
 - Memory usage: <512MB baseline
 
 ## Historical Documentation
-Historical reports and analysis documents are preserved in the [archive](archive/) directory:
-- `reports-2025-05-24/` - Repository cleanup, system reviews, and test results
-- Previous cleanup and migration documents
-
-All critical information from these documents has been incorporated into the main documentation.
+Historical reports and analysis documents were previously stored in an `archive/` directory.
+That directory has been removed after consolidation, and all critical information has been
+incorporated into the main documentation.


### PR DESCRIPTION
## Summary
- clarify removal of old archive in docs/README
- update consolidation summary about the deleted archive directory

## Testing
- `make test` *(fails: turbo not found)*