### PR TITLE
Remove validator service from startup scripts

### DIFF
--- a/run-phoenix.sh
+++ b/run-phoenix.sh
@@ -127,11 +127,8 @@ update_configs() {
 build_services() {
     echo -e "\n${YELLOW}Building services...${NC}"
     
-    # Build specific services that have been updated
-    echo -e "${BLUE}Building validator service...${NC}"
-    docker build -f services/validator/Dockerfile -t phoenix-validator:latest services/validator/
-    
-    echo -e "${BLUE}Building other services...${NC}"
+    # Build updated services
+    echo -e "${BLUE}Building services...${NC}"
     make build-docker || true
 }
 

--- a/scripts/consolidated/core/run-phoenix.sh
+++ b/scripts/consolidated/core/run-phoenix.sh
@@ -127,11 +127,8 @@ update_configs() {
 build_services() {
     echo -e "\n${YELLOW}Building services...${NC}"
     
-    # Build specific services that have been updated
-    echo -e "${BLUE}Building validator service...${NC}"
-    docker build -f services/validator/Dockerfile -t phoenix-validator:latest services/validator/
-    
-    echo -e "${BLUE}Building other services...${NC}"
+    # Build updated services
+    echo -e "${BLUE}Building services...${NC}"
     make build-docker || true
 }
 

--- a/scripts/consolidated/deployment/test-deployment.sh
+++ b/scripts/consolidated/deployment/test-deployment.sh
@@ -25,7 +25,6 @@ REQUIRED_DIRS=(
     "services/control-plane/actuator"
     "services/generators/synthetic"
     "services/generators/complex"
-    "services/validator"
     "infrastructure/docker/compose"
     "configs/monitoring/prometheus"
     "configs/monitoring/grafana"


### PR DESCRIPTION
## Summary
- remove validator service build lines from `run-phoenix.sh`
- remove validator service build lines from consolidated run script
- remove validator directory check from deployment test

## Testing
- `npm test` *(fails: turbo not found)*