### PR TITLE
Fix docs and validation script paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ terraform apply
 
 # Deploy Phoenix
 cd ../../../..
-./infrastructure/scripts/deploy-aws.sh
+./scripts/consolidated/deployment/deploy-aws.sh
 ```
 
 ### Azure AKS Deployment
@@ -409,22 +409,9 @@ terraform apply
 
 # Deploy Phoenix
 cd ../../../..
-./infrastructure/scripts/deploy-azure.sh
+./scripts/consolidated/deployment/deploy-azure.sh
 ```
 
-### Cloud Deployment
-
-```bash
-# Using Helm for container services
-helm install phoenix ./infrastructure/helm/phoenix \
-  --namespace phoenix \
-  --create-namespace \
-  --values ./infrastructure/helm/phoenix/values.yaml
-
-# Using Terraform for infrastructure
-cd infrastructure/terraform/environments/aws
-terraform init && terraform apply
-```
 
 ## 💻 Development
 

--- a/scripts/consolidated/monitoring/validate-system.sh
+++ b/scripts/consolidated/monitoring/validate-system.sh
@@ -214,8 +214,6 @@ echo -e "\n${YELLOW}🏗️ Infrastructure Validation${NC}"
 
 run_test "Terraform AWS module exists" "[ -d infrastructure/terraform/modules/aws-phoenix ]"
 run_test "Terraform environments exist" "[ -d infrastructure/terraform/environments/aws ]"
-run_test "Helm charts exist" "[ -d infrastructure/helm ]"
-run_test "Helm chart exists" "[ -d infrastructure/helm/phoenix ]"
 
 # 11. Environment Configuration Validation
 echo -e "\n${YELLOW}🌍 Environment Configuration Validation${NC}"


### PR DESCRIPTION
## Summary
- update AWS and Azure deployment commands in README
- remove outdated Helm instructions from README
- drop helm directory checks in validation script

## Testing
- `npm test` *(fails: turbo not found)*