### PR TITLE
Add functional OTel processor stubs

### DIFF
--- a/go.work
+++ b/go.work
@@ -8,4 +8,5 @@ use (
 	./projects/phoenix-cli
 	./projects/pipeline-operator
 	./projects/platform-api
+	./projects/collector
 )

--- a/pkg/otel/processors/adaptivefilter/adaptive_filter.go
+++ b/pkg/otel/processors/adaptivefilter/adaptive_filter.go
@@ -1,0 +1,66 @@
+package adaptivefilter
+
+import (
+	"fmt"
+
+	"github.com/phoenix/platform/pkg/otel"
+)
+
+// Config defines thresholds for filtering.
+type Config struct {
+	CPUPercent float64
+	MemoryMB   float64
+}
+
+// Processor drops metrics below configured thresholds.
+type Processor struct {
+	cpu float64
+	mem float64
+}
+
+// Process filters metrics based on CPU and memory thresholds.
+func (p *Processor) Process(metrics []otel.Metric) []otel.Metric {
+	var out []otel.Metric
+	for _, m := range metrics {
+		if m.Name == "process.cpu.utilization" && m.Value < p.cpu {
+			continue
+		}
+		if m.Name == "process.memory.usage" && m.Value < p.mem {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// Factory creates adaptive filter processors.
+type Factory struct{}
+
+// Type returns the processor type name.
+func (Factory) Type() string { return "phoenix/adaptive_filter" }
+
+// Create instantiates a processor from config.
+func (Factory) Create(cfg map[string]interface{}) (otel.Processor, error) {
+	thresholds, ok := cfg["base_thresholds"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("base_thresholds required")
+	}
+	cpu := toFloat64(thresholds["cpu_percent"])
+	mem := toFloat64(thresholds["memory_mb"])
+	return &Processor{cpu: cpu, mem: mem}, nil
+}
+
+func toFloat64(v interface{}) float64 {
+	switch t := v.(type) {
+	case int:
+		return float64(t)
+	case float64:
+		return t
+	default:
+		return 0
+	}
+}
+
+func init() {
+	otel.RegisterProcessorFactory(&Factory{})
+}

--- a/pkg/otel/processors/adaptivefilter/adaptive_filter_test.go
+++ b/pkg/otel/processors/adaptivefilter/adaptive_filter_test.go
@@ -1,0 +1,30 @@
+package adaptivefilter
+
+import (
+	"testing"
+
+	"github.com/phoenix/platform/pkg/otel"
+)
+
+func TestProcessor(t *testing.T) {
+	factory := &Factory{}
+	proc, err := factory.Create(map[string]interface{}{
+		"base_thresholds": map[string]interface{}{
+			"cpu_percent": 2.0,
+			"memory_mb":   100.0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	metrics := []otel.Metric{
+		{Name: "process.cpu.utilization", Value: 1},
+		{Name: "process.cpu.utilization", Value: 5},
+		{Name: "process.memory.usage", Value: 50},
+		{Name: "process.memory.usage", Value: 200},
+	}
+	out := proc.Process(metrics)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 metrics, got %d", len(out))
+	}
+}

--- a/pkg/otel/processors/topk/topk.go
+++ b/pkg/otel/processors/topk/topk.go
@@ -1,0 +1,67 @@
+package topk
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/phoenix/platform/pkg/otel"
+)
+
+// Config defines the processor configuration.
+type Config struct {
+	MetricName string
+	TopK       int
+}
+
+// Processor keeps only the top K metrics for a metric name.
+type Processor struct {
+	metricName string
+	topK       int
+}
+
+// Process filters metrics keeping only the top K for the configured metric name.
+func (p *Processor) Process(metrics []otel.Metric) []otel.Metric {
+	var target []otel.Metric
+	var rest []otel.Metric
+	for _, m := range metrics {
+		if m.Name == p.metricName {
+			target = append(target, m)
+		} else {
+			rest = append(rest, m)
+		}
+	}
+	sort.Slice(target, func(i, j int) bool { return target[i].Value > target[j].Value })
+	if len(target) > p.topK {
+		target = target[:p.topK]
+	}
+	return append(target, rest...)
+}
+
+// Factory creates top-k processors.
+type Factory struct{}
+
+// Type returns the processor type.
+func (Factory) Type() string { return "phoenix/topk" }
+
+// Create instantiates a new processor from config.
+func (Factory) Create(cfg map[string]interface{}) (otel.Processor, error) {
+	metricName, _ := cfg["metric_name"].(string)
+	if metricName == "" {
+		return nil, fmt.Errorf("metric_name required")
+	}
+	var k int
+	switch v := cfg["top_k"].(type) {
+	case int:
+		k = v
+	case float64:
+		k = int(v)
+	}
+	if k <= 0 {
+		return nil, fmt.Errorf("top_k must be > 0")
+	}
+	return &Processor{metricName: metricName, topK: k}, nil
+}
+
+func init() {
+	otel.RegisterProcessorFactory(&Factory{})
+}

--- a/pkg/otel/processors/topk/topk_test.go
+++ b/pkg/otel/processors/topk/topk_test.go
@@ -1,0 +1,30 @@
+package topk
+
+import (
+	"testing"
+
+	"github.com/phoenix/platform/pkg/otel"
+)
+
+func TestProcessor(t *testing.T) {
+	factory := &Factory{}
+	proc, err := factory.Create(map[string]interface{}{
+		"metric_name": "cpu",
+		"top_k":       2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	metrics := []otel.Metric{
+		{Name: "cpu", Value: 3},
+		{Name: "cpu", Value: 1},
+		{Name: "cpu", Value: 2},
+	}
+	out := proc.Process(metrics)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 metrics, got %d", len(out))
+	}
+	if out[0].Value != 3 || out[1].Value != 2 {
+		t.Fatalf("unexpected ordering: %#v", out)
+	}
+}

--- a/pkg/otel/registry.go
+++ b/pkg/otel/registry.go
@@ -1,0 +1,40 @@
+package otel
+
+import "github.com/phoenix/platform/pkg/analytics"
+
+// Metric represents a single metric data point used by processors.
+type Metric = analytics.Metric
+
+// Processor processes a slice of metrics and returns the result.
+type Processor interface {
+	Process([]Metric) []Metric
+}
+
+// ProcessorFactory creates processors based on configuration.
+type ProcessorFactory interface {
+	// Type returns the unique processor type name.
+	Type() string
+	// Create creates a processor from config options.
+	Create(config map[string]interface{}) (Processor, error)
+}
+
+var processorFactories = map[string]ProcessorFactory{}
+
+// RegisterProcessorFactory registers a processor factory.
+func RegisterProcessorFactory(factory ProcessorFactory) {
+	if factory == nil {
+		return
+	}
+	processorFactories[factory.Type()] = factory
+}
+
+// GetProcessorFactory retrieves a registered factory by name.
+func GetProcessorFactory(name string) (ProcessorFactory, bool) {
+	f, ok := processorFactories[name]
+	return f, ok
+}
+
+// ClearProcessorFactories removes all registered factories.
+func ClearProcessorFactories() {
+	processorFactories = map[string]ProcessorFactory{}
+}

--- a/pkg/otel/registry_test.go
+++ b/pkg/otel/registry_test.go
@@ -1,0 +1,16 @@
+package otel
+
+import "testing"
+
+type dummyFactory struct{}
+
+func (dummyFactory) Type() string                                     { return "dummy" }
+func (dummyFactory) Create(map[string]interface{}) (Processor, error) { return nil, nil }
+
+func TestRegisterProcessorFactory(t *testing.T) {
+	ClearProcessorFactories()
+	RegisterProcessorFactory(dummyFactory{})
+	if _, ok := GetProcessorFactory("dummy"); !ok {
+		t.Fatalf("factory not registered")
+	}
+}

--- a/projects/collector/cmd/collector/main.go
+++ b/projects/collector/cmd/collector/main.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	_ "github.com/phoenix/platform/pkg/otel/processors/adaptivefilter"
+	_ "github.com/phoenix/platform/pkg/otel/processors/topk"
+)
+
+func main() {}

--- a/projects/collector/go.mod
+++ b/projects/collector/go.mod
@@ -1,0 +1,7 @@
+module github.com/phoenix/platform/projects/collector
+
+go 1.24.0
+
+require github.com/phoenix/platform/pkg v0.0.0
+
+replace github.com/phoenix/platform/pkg => ../../pkg


### PR DESCRIPTION
## Summary
- add minimal OTel processor registry
- implement `phoenix/topk` and `phoenix/adaptive_filter` processors
- register processors via new collector module
- include focused unit tests

## Testing
- `go test ./pkg/otel/...`